### PR TITLE
feat: Workday tenant passthrough + 7-ATS doc corrections (0.6.0)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,7 @@
                     <ol class="how-steps how-steps-compact">
                         <li><strong>You ask your AI</strong> for anything that needs current job data.</li>
                         <li><strong>jd-intel fetches</strong> via a small local MCP server.</li>
-                        <li><strong>Greenhouse, Lever, Ashby return JDs.</strong> Public APIs, no scraping.</li>
+                        <li><strong>Greenhouse, Lever, Ashby + 4 more return JDs.</strong> Public APIs, no scraping.</li>
                     </ol>
                 </div>
             </div>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # jd-intel-mcp
 
-MCP server for [jd-intel](https://github.com/prPMDev/jd-intel). Lets any AI assistant (Claude Desktop, Cursor, Windsurf) search open job listings across Greenhouse, Lever, and Ashby through natural conversation.
+MCP server for [jd-intel](https://github.com/prPMDev/jd-intel). Lets any AI assistant (Claude Desktop, Cursor, Windsurf) search open job listings across Greenhouse, Lever, Ashby, SmartRecruiters, Teamtailor, Recruitee, and Workday through natural conversation.
 
 > **Stop pasting job descriptions into AI assistants. Let your AI fetch them directly.**
 
@@ -9,7 +9,7 @@ MCP server for [jd-intel](https://github.com/prPMDev/jd-intel). Lets any AI assi
 ## What you can ask
 
 - "Is Stripe hiring PMs in the US?"
-- "Find remote engineering roles at fintech companies, posted in the last two weeks, then draft a cover letter for the best match."
+- "Find remote engineering roles at fintech companies, posted in the last two weeks, then rank them by fit for a senior backend profile."
 - "What companies in your index are in the developer tools space?"
 - "Does Figma use Greenhouse or Lever?"
 

--- a/mcp/descriptions.js
+++ b/mcp/descriptions.js
@@ -8,7 +8,7 @@
  * the AI's behavior changes immediately when descriptions change.
  */
 
-export const FETCH_JOBS = `Fetch open job postings from a specific company's ATS (Greenhouse, Lever, or Ashby).
+export const FETCH_JOBS = `Fetch open job postings from a specific company's ATS (Greenhouse, Lever, Ashby, SmartRecruiters, Teamtailor, Recruitee, Workday).
 
 USE WHEN: the user asks about roles at a known company ("Is Stripe hiring?", "What's open at Figma?").
 
@@ -60,7 +60,7 @@ RESPONSE: { status, data: [{ slug, name, sector, ats }], metadata }. Each result
 ERROR CODES:
 - invalid_args: both query and sector missing`;
 
-export const DETECT_ATS = `Detect which ATS platform (Greenhouse, Lever, or Ashby) a company uses.
+export const DETECT_ATS = `Detect which ATS platform (Greenhouse, Lever, Ashby, SmartRecruiters, Teamtailor, Recruitee) a company uses by probing. Workday is registry-only and never returned here; find Workday-hosted companies via search_registry or fetch_jobs (which auto-detects from the registry).
 
 USE WHEN: user asks about the ATS platform explicitly ("What ATS does Stripe use?") or for debugging.
 
@@ -70,7 +70,7 @@ ARGUMENT GUIDE:
 
 company: company name or slug. Hyphens and spaces stripped automatically ("Cockroach Labs" → "cockroachlabs").
 
-RESPONSE: { status, data: "greenhouse" | "lever" | "ashby" | null, metadata }. data === null means no supported ATS hosts this company. "partial" status means some probes failed. Result may be incomplete.
+RESPONSE: { status, data: "greenhouse" | "lever" | "ashby" | "smartrecruiters" | "teamtailor" | "recruitee" | null, metadata }. data === null means none of the probeable ATS host this company (Workday is registry-only and never detected here). "partial" status means some probes failed. Result may be incomplete.
 
 ERROR CODES:
 - invalid_args: company arg missing
@@ -80,4 +80,4 @@ export const REGISTRY_RESOURCE = `The full jd-intel company registry, grouped by
 
 Use for broad surveys ("what fintech companies are indexed?", "tell me about the catalog"). Fetched once per session, then cached. Cheaper than repeated search_registry calls for multi-query reasoning.
 
-Shape: { greenhouse: [{slug, name, sector}], lever: [...], ashby: [...] }.`;
+Shape: { greenhouse: [{slug, name, sector}], lever: [...], ashby: [...], smartrecruiters: [...], teamtailor: [...], recruitee: [...], workday: [...] }.`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jd-intel",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Fetch and normalize job descriptions across every major ATS (Greenhouse, Lever, Ashby, Workday, and more) — for your AI assistant, no copy-paste.",
   "type": "module",
   "main": "src/index.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -23,7 +23,7 @@ async function main() {
         const idx = args.indexOf(flag);
         return idx >= 0 ? args[idx + 1] : undefined;
       };
-      const ats = getArg('--ats');
+      let ats = getArg('--ats');
       const titleFilter = getArg('--title-filter');
       const filter = getArg('--filter');
       const postedWithinRaw = getArg('--posted-within-days');
@@ -35,6 +35,28 @@ async function main() {
       const limitRaw = getArg('--limit');
       const limit = limitRaw !== undefined ? Number(limitRaw) : undefined;
 
+      // Workday is keyed by a {tenant, env, site} triple, not a slug.
+      // Supplying it here makes a Workday board reachable without a
+      // registry entry; presence of the flags infers --ats workday.
+      const wdTenant = getArg('--workday-tenant');
+      const wdEnv = getArg('--workday-env');
+      const wdSite = getArg('--workday-site');
+      let config;
+      if (wdTenant || wdEnv || wdSite) {
+        if (!wdTenant || !wdEnv || !wdSite) {
+          console.error('Workday needs all three: --workday-tenant, --workday-env, --workday-site.');
+          console.error('Find them in the careers URL: https://{tenant}.{env}.myworkdayjobs.com/{site}');
+          console.error('e.g. https://expedia.wd108.myworkdayjobs.com/search  ->  --workday-tenant expedia --workday-env wd108 --workday-site search');
+          process.exit(1);
+        }
+        if (ats && ats !== 'workday') {
+          console.error(`--ats ${ats} conflicts with the --workday-* flags (workday is inferred). Drop one.`);
+          process.exit(1);
+        }
+        config = { tenant: wdTenant, env: wdEnv, site: wdSite };
+        ats = 'workday';
+      }
+
       const parts = [];
       if (titleFilter) parts.push(`title: ${titleFilter}`);
       if (filter) parts.push(`topic: ${filter}`);
@@ -43,10 +65,23 @@ async function main() {
       if (locationExcludes) parts.push(`loc-: ${locationExcludes.join('|')}`);
       const suffix = parts.length ? ` [${parts.join(', ')}]` : '';
 
-      console.log(`Fetching jobs from ${company}${ats ? ` (${ats})` : ' (auto-detect)'}${suffix}...`);
-      const jobs = await fetchJobs({
-        company, ats, titleFilter, filter, postedWithinDays, locationIncludes, locationExcludes, limit,
-      });
+      const atsLabel = config
+        ? ` (workday: ${config.tenant}/${config.env}/${config.site})`
+        : ats ? ` (${ats})` : ' (auto-detect)';
+      console.log(`Fetching jobs from ${company}${atsLabel}${suffix}...`);
+      let jobs;
+      try {
+        jobs = await fetchJobs({
+          company, ats, config, titleFilter, filter, postedWithinDays, locationIncludes, locationExcludes, limit,
+        });
+      } catch (err) {
+        if (config) {
+          console.error(`Could not reach that Workday board (${config.tenant}/${config.env}/${config.site}): ${err.message}`);
+          console.error('Verify the triple against the careers URL: https://{tenant}.{env}.myworkdayjobs.com/{site}');
+          process.exit(1);
+        }
+        throw err;
+      }
       console.log(`Found ${jobs.length} jobs\n`);
 
       for (const job of jobs.slice(0, 20)) {
@@ -115,9 +150,15 @@ Fetch options:
   --ats <platform>                Skip auto-detect. One of: greenhouse, lever,
                                   ashby, smartrecruiters, teamtailor, recruitee,
                                   workday. Omit to auto-detect (registry-backed).
-                                  Workday is registry-only: fetch it by company
-                                  slug and let auto-detect route it, not via
-                                  --ats workday.
+  --workday-tenant T              Workday is keyed by a {tenant, env, site}
+  --workday-env wdN               triple, not a slug. Registered Workday
+  --workday-site S                companies work via auto-detect or --ats
+                                  workday; for any other Workday board pass
+                                  all three, read from the careers URL
+                                  https://{tenant}.{env}.myworkdayjobs.com/{site}
+                                  e.g. https://expedia.wd108.myworkdayjobs.com/search
+                                  -> --workday-tenant expedia --workday-env wd108
+                                     --workday-site search
   --title-filter pattern          Regex matched against TITLE only (role identity)
   --filter pattern                Regex matched across title, department, description (topic/scope)
   --posted-within-days N          Only jobs posted in the last N days
@@ -137,6 +178,7 @@ Examples:
   jd-intel fetch stripe --title-filter "product manager" --filter "growth|platform"
   jd-intel fetch ramp --location-include "United States,US,Remote - US" --location-exclude "London,Dublin"
   jd-intel fetch notion --ats ashby --title-filter engineer --posted-within-days 14
+  jd-intel fetch expedia --workday-tenant expedia --workday-env wd108 --workday-site search
   jd-intel detect figma
   jd-intel registry search fintech`);
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@
  * jd-intel CLI
  *
  * Usage:
- *   jd-intel fetch <company> [--ats greenhouse|lever|ashby] [--filter keyword|pattern]
+ *   jd-intel fetch <company> [--ats <platform>] [--filter keyword|pattern]
  *   jd-intel detect <company>
  *   jd-intel registry search <query>
  */
@@ -18,7 +18,7 @@ async function main() {
   switch (command) {
     case 'fetch': {
       const company = args[0];
-      if (!company) { console.error('Usage: jd-intel fetch <company> [--ats greenhouse|lever|ashby]'); process.exit(1); }
+      if (!company) { console.error('Usage: jd-intel fetch <company> [--ats <platform>]  (omit --ats to auto-detect; run "jd-intel" for the platform list)'); process.exit(1); }
       const getArg = (flag) => {
         const idx = args.indexOf(flag);
         return idx >= 0 ? args[idx + 1] : undefined;
@@ -112,7 +112,12 @@ Usage:
   jd-intel registry search <query>
 
 Fetch options:
-  --ats greenhouse|lever|ashby    Skip auto-detect
+  --ats <platform>                Skip auto-detect. One of: greenhouse, lever,
+                                  ashby, smartrecruiters, teamtailor, recruitee,
+                                  workday. Omit to auto-detect (registry-backed).
+                                  Workday is registry-only: fetch it by company
+                                  slug and let auto-detect route it, not via
+                                  --ats workday.
   --title-filter pattern          Regex matched against TITLE only (role identity)
   --filter pattern                Regex matched across title, department, description (topic/scope)
   --posted-within-days N          Only jobs posted in the last N days

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { applyFilters } from './filters.js';
  * @param {Object} options
  * @param {string} options.company - Company slug or name
  * @param {string} [options.ats] - Specific ATS platform. If omitted, auto-detects.
+ * @param {object} [options.config] - Adapter-specific config (e.g. Workday {tenant, env, site}). Bypasses the registry; the only way to reach a Workday company not in the registry.
  * @param {string} [options.titleFilter] - Regex matched against title only. Use for role identity ("product manager", "staff engineer").
  * @param {string} [options.filter] - Regex matched across title, department, description. Use for topic/scope.
  * @param {number} [options.postedWithinDays] - Only return jobs posted within N days.
@@ -27,6 +28,7 @@ import { applyFilters } from './filters.js';
 export async function fetchJobs({
   company,
   ats,
+  config,
   titleFilter,
   filter,
   postedWithinDays,
@@ -49,16 +51,33 @@ export async function fetchJobs({
   if (ats) {
     const adapter = ADAPTERS[ats];
     if (!adapter) throw new Error(`Unknown ATS: ${ats}. Supported: ${ATS_NAMES.join(', ')}`);
-    jobs = await adapter.fetch(slug, { filterContext });
+    // Explicit ATS: an explicitly passed config wins (the only path that
+    // can reach a Workday company not in the registry). With no explicit
+    // config, fall back to the registry so config-keyed adapters
+    // (Workday) and canonically-cased registry slugs (SmartRecruiters
+    // "Visa") also work on the explicit path, not just under auto-detect.
+    let fetchSlug = slug;
+    let cfg = config;
+    let companyName;
+    if (!cfg) {
+      const hit = await findEntryBySlug(slug);
+      if (hit && hit.ats === ats) {
+        fetchSlug = hit.entry.slug;
+        cfg = hit.entry.config;
+        companyName = hit.entry.name;
+      }
+    }
+    jobs = await adapter.fetch(fetchSlug, { config: cfg, companyName, filterContext });
   } else {
     // Consult registry first — if we know which ATS this company uses,
     // skip probing the others (saves API calls, clearer error semantics).
-    // The full entry is needed so adapter-specific config (e.g. the
-    // Workday {tenant,env,site} triple) reaches the adapter.
+    // The registry entry carries the canonical slug (so the adapter is
+    // called with the ATS's own casing, e.g. SmartRecruiters "Visa") and
+    // any adapter-specific config (the Workday {tenant,env,site} triple).
     const hit = await findEntryBySlug(slug);
     if (hit) {
-      jobs = await ADAPTERS[hit.ats].fetch(slug, {
-        config: hit.entry.config,
+      jobs = await ADAPTERS[hit.ats].fetch(hit.entry.slug, {
+        config: config || hit.entry.config,
         companyName: hit.entry.name,
         filterContext,
       });

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@
  * jd-intel — JD intelligence toolkit: fetch, normalize, and search job descriptions across every major ATS.
  *
  * Fetches, normalizes, and enriches job data from public ATS APIs
- * (Greenhouse, Lever, Ashby) into a unified schema.
+ * (Greenhouse, Lever, Ashby, SmartRecruiters, Teamtailor, Recruitee,
+ * Workday) into a unified schema.
  */
 
 import { ADAPTERS, ATS_NAMES } from './adapters/index.js';
@@ -92,7 +93,7 @@ export { detectAts } from './registry.js';
 
 /**
  * Look up which ATS a slug belongs to in the registry (cached, no network).
- * Returns the ATS name ("greenhouse" | "lever" | "ashby") or null if not in registry.
+ * Returns the ATS name (e.g. "greenhouse", "workday") or null if not in registry.
  */
 export { findAtsBySlug } from './registry.js';
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -58,14 +58,21 @@ export async function searchRegistry(query) {
   return results;
 }
 
+// Slug match is case/punctuation-insensitive: registry slugs are stored
+// in each ATS's canonical form (SmartRecruiters uses PascalCase, e.g.
+// "Visa"), but callers pass a lowercased/alnum-stripped slug. Comparing
+// normalized forms keeps registry-first routing working for those.
+const normSlug = (s) => String(s).toLowerCase().replace(/[^a-z0-9]/g, '');
+
 /**
  * Look up which ATS a slug belongs to in the registry.
  * Returns the ATS name (e.g., "greenhouse") or null if not in registry.
  */
 export async function findAtsBySlug(slug) {
   const all = await loadRegistry();
+  const key = normSlug(slug);
   for (const [ats, companies] of Object.entries(all)) {
-    if (companies.some(c => c.slug === slug)) return ats;
+    if (companies.some(c => normSlug(c.slug) === key)) return ats;
   }
   return null;
 }
@@ -81,8 +88,9 @@ export async function findAtsBySlug(slug) {
  */
 export async function findEntryBySlug(slug) {
   const all = await loadRegistry();
+  const key = normSlug(slug);
   for (const [ats, companies] of Object.entries(all)) {
-    const entry = companies.find(c => c.slug === slug);
+    const entry = companies.find(c => normSlug(c.slug) === key);
     if (entry) return { ats, entry };
   }
   return null;

--- a/test/fetch-jobs.test.js
+++ b/test/fetch-jobs.test.js
@@ -1,0 +1,95 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchJobs } from '../src/index.js';
+
+/**
+ * fetchJobs routing: explicit-ATS config passthrough (Workday reachable
+ * without a registry entry), registry fallback on the explicit path,
+ * config-over-registry precedence, and canonical-cased slug routing for
+ * case-sensitive registries (SmartRecruiters). Mocks global fetch
+ * (auto-restored per test by t.mock.method).
+ */
+
+const WD_LIST = {
+  total: 1,
+  jobPostings: [
+    { title: 'Product Manager', externalPath: '/job/Remote/PM_R1', locationsText: 'Remote', postedOn: 'Posted Today' },
+  ],
+};
+const WD_DETAIL = { jobPostingInfo: { jobDescription: '<p>Build.</p>', startDate: '2026-05-01', location: 'Remote' } };
+
+function workdayMock(t) {
+  const calls = { urls: [] };
+  t.mock.method(global, 'fetch', async (url) => {
+    calls.urls.push(String(url));
+    if (String(url).endsWith('/jobs')) return { ok: true, status: 200, json: async () => WD_LIST };
+    return { ok: true, status: 200, json: async () => WD_DETAIL };
+  });
+  return calls;
+}
+
+describe('fetchJobs — Workday config passthrough', () => {
+  test('explicit ats=workday + config reaches the adapter with that triple', async (t) => {
+    const calls = workdayMock(t);
+    const jobs = await fetchJobs({
+      company: 'expedia',
+      ats: 'workday',
+      config: { tenant: 'expedia', env: 'wd108', site: 'search' },
+    });
+    assert.equal(jobs.length, 1);
+    assert.equal(jobs[0].title, 'Product Manager');
+    assert.ok(
+      calls.urls.includes('https://expedia.wd108.myworkdayjobs.com/wday/cxs/expedia/search/jobs'),
+      `expected the passthrough triple in the list URL, got: ${calls.urls[0]}`
+    );
+  });
+
+  test('explicit ats=workday with NO config falls back to registry config', async (t) => {
+    const calls = workdayMock(t);
+    const jobs = await fetchJobs({ company: 'cisco', ats: 'workday' });
+    assert.equal(jobs.length, 1);
+    assert.ok(
+      calls.urls.includes('https://cisco.wd5.myworkdayjobs.com/wday/cxs/cisco/Cisco_Careers/jobs'),
+      `expected registry-fallback triple, got: ${calls.urls[0]}`
+    );
+  });
+
+  test('explicit config overrides the registry entry', async (t) => {
+    const calls = workdayMock(t);
+    await fetchJobs({
+      company: 'cisco',
+      ats: 'workday',
+      config: { tenant: 'override', env: 'wd99', site: 'OverrideSite' },
+    });
+    assert.ok(
+      calls.urls.some(u => u.startsWith('https://override.wd99.myworkdayjobs.com/')),
+      `expected explicit config to win, got: ${calls.urls[0]}`
+    );
+    assert.ok(
+      !calls.urls.some(u => u.includes('cisco.wd5')),
+      'registry config must not be used when explicit config is given'
+    );
+  });
+});
+
+describe('fetchJobs — canonical-cased registry slug routing', () => {
+  test('auto-detect routes a PascalCase SmartRecruiters slug from lowercased input', async (t) => {
+    const calls = { urls: [] };
+    t.mock.method(global, 'fetch', async (url) => {
+      calls.urls.push(String(url));
+      return { ok: true, status: 200, json: async () => ({ content: [], totalFound: 0 }) };
+    });
+    const jobs = await fetchJobs({ company: 'visa' }); // no ats -> registry-routed
+    assert.deepEqual(jobs, []);
+    // Routed via the registry to a single adapter using the canonical
+    // 'Visa' (not lowercased 'visa', not 7-adapter discovery probing).
+    assert.ok(
+      calls.urls.length > 0 && calls.urls.every(u => u.includes('api.smartrecruiters.com')),
+      `expected only SmartRecruiters calls (registry-routed), got: ${calls.urls.join(', ')}`
+    );
+    assert.ok(
+      calls.urls.some(u => u.includes('/v1/companies/Visa/postings')),
+      `expected canonical 'Visa' in the URL, got: ${calls.urls[0]}`
+    );
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -75,6 +75,14 @@ describe('findAtsBySlug', () => {
     assert.equal(await findAtsBySlug('plaid'), 'lever');
   });
 
+  test('matches case-insensitively (PascalCase SmartRecruiters slug)', async () => {
+    // Registry stores "Visa"; callers pass a lowercased/stripped slug.
+    // Pre-fix this returned null and every SR company missed registry
+    // routing (fell through to slow 7-adapter discovery probing).
+    assert.equal(await findAtsBySlug('visa'), 'smartrecruiters');
+    assert.equal(await findAtsBySlug('VISA'), 'smartrecruiters');
+  });
+
   test('returns null for unknown slug', async () => {
     const ats = await findAtsBySlug('zzzz-nonexistent-slug-zzzz');
     assert.equal(ats, null);
@@ -96,6 +104,13 @@ describe('findEntryBySlug', () => {
     assert.ok(hit);
     assert.equal(hit.ats, 'greenhouse');
     assert.equal(hit.entry.slug, 'stripe');
+  });
+
+  test('resolves a PascalCase slug from lowercase and returns canonical casing', async () => {
+    const hit = await findEntryBySlug('visa');
+    assert.ok(hit, 'Visa should resolve from "visa"');
+    assert.equal(hit.ats, 'smartrecruiters');
+    assert.equal(hit.entry.slug, 'Visa'); // canonical, not the lowercased input
   });
 
   test('returns null for unknown slug', async () => {


### PR DESCRIPTION
## Summary
- **0.6.0 feature:** CLI `--workday-tenant/-env/-site` passthrough so any Workday board is reachable by its `{tenant,env,site}` triple without a registry entry; infers `ats=workday`, fail-fast on incomplete triple, clear bad-triple error, `--help` URL-derivation hint.
- **`fetchJobs` unification:** optional `config` param; explicit-`--ats` branch now consults the registry for config + canonical slug — fixes explicit `--ats workday` returning `[]`, and the SmartRecruiters registry-miss routing (case-insensitive match + canonical casing, also fixes `findAtsBySlug` returning null for PascalCase SR slugs).
- **Docs (Part 1):** advertised ATS support corrected 3 → 7 across CLI `--help`, library JSDoc, MCP tool descriptions, mcp/README, landing page; cover-letter example copy fixed.
- Bump **0.6.0 root only**; MCP structured-arg parity intentionally deferred to a fast-follow (mcp publish idempotent-skips).

## Test plan
- [x] `node --test test/*.test.js` — 130/130 green (124 prior + 6 new)
- [x] Live Workday passthrough smoke across 5 tenants/pods (Expedia, Salesforce, Adobe, Bank of America [tenant ghr ≠ slug], Nvidia)
- [x] CLI cases: happy path, incomplete triple, `--ats` conflict, bad triple (clear error, exit 1)
- [x] SmartRecruiters end-to-end verified working (registry routing + canonical slug)