### PR TITLE
feat(mcp): Workday tenant passthrough on fetch_jobs (jd-intel-mcp 0.6.0)

### DIFF
--- a/mcp/descriptions.js
+++ b/mcp/descriptions.js
@@ -32,12 +32,14 @@ location_excludes: array. Drop jobs whose location contains any keyword. Use as 
 
 limit: default 100. Reduce for high-volume companies.
 
+workday: optional { tenant, env, site }. Use ONLY for a Workday company not in the registry when the user gives a careers URL. Derive from https://{tenant}.{env}.myworkdayjobs.com/{site}: tenant is the first label, env is the part like wd108, site is the path segment. Overrides the registry for that fetch. Never guess or fabricate these values; use only what the user supplied or what is literally in the careers URL. Omit this argument entirely if you do not have a real URL.
+
 RESPONSE: { status, data: [jobs], metadata: { attempted, succeeded, failed, notes } }. Check status first. "partial" means some adapters failed. Tell the user results may be incomplete.
 
 ERROR CODES:
 - company_not_found: slug not in registry, not detected
-- ats_unreachable: known ATS failed
-- invalid_args: missing/malformed args
+- ats_unreachable: known ATS failed, or a supplied workday {tenant,env,site} was rejected by Workday
+- invalid_args: missing/malformed args, including an incomplete workday triple
 - rate_limited: upstream 429`;
 
 export const SEARCH_REGISTRY = `Find companies in the indexed registry by name or sector.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "jd-intel-mcp",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jd-intel-mcp",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "jd-intel": "^0.1.0",
+        "jd-intel": "^0.6.0",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -658,9 +658,9 @@
       "license": "ISC"
     },
     "node_modules/jd-intel": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/jd-intel/-/jd-intel-0.1.0.tgz",
-      "integrity": "sha512-p17+Tk+klzqWDihTLXGZOUauhIBHzdQpafTtCQcK6vQ+ndepWxg08LSoXLwBrYOJDczJfbIUvptHeKooiMVdoQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jd-intel/-/jd-intel-0.6.0.tgz",
+      "integrity": "sha512-8HV4QjFODT8l9DzEgzMlVVx/mlxjhE7F8rnULpIAiLC+zaQhL0eromLNFhJ5VTsknq7qs6KeDoDdSmBKoasLfg==",
       "license": "MIT",
       "bin": {
         "jd-intel": "src/cli.js"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jd-intel-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server for jd-intel. Your AI assistant fetches and reasons over full job descriptions, no copy-paste.",
   "type": "module",
   "main": "server.js",
@@ -22,11 +22,12 @@
     "start": "node server.js",
     "dev": "node --watch server.js",
     "install:local": "node cli.js install",
-    "uninstall:local": "node cli.js uninstall"
+    "uninstall:local": "node cli.js uninstall",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "jd-intel": "^0.5.0",
+    "jd-intel": "^0.6.0",
     "zod": "^3.23.0"
   },
   "keywords": [

--- a/mcp/test/tools.test.js
+++ b/mcp/test/tools.test.js
@@ -1,0 +1,91 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerTools } from '../tools.js';
+
+/**
+ * First automated MCP test. Uses the registerTools(server, deps) seam to
+ * inject a mock library, so this is offline and asserts the AI-facing
+ * contract: how the `workday` arg maps to the library `fetchJobs` call,
+ * the envelope metadata, and the error-code taxonomy.
+ */
+
+function getFetchJobsHandler(deps) {
+  const handlers = {};
+  const fakeServer = { registerTool: (name, _def, handler) => { handlers[name] = handler; } };
+  registerTools(fakeServer, deps);
+  return handlers.fetch_jobs;
+}
+
+const parse = (result) => JSON.parse(result.content[0].text);
+
+describe('mcp fetch_jobs — workday passthrough', () => {
+  test('workday triple maps to ats:workday + config and sets metadata', async () => {
+    let received;
+    const handler = getFetchJobsHandler({
+      fetchJobs: async (opts) => { received = opts; return [{ title: 'PM' }]; },
+      findAtsBySlug: async () => null,
+    });
+    const result = await handler({
+      company: 'expedia',
+      workday: { tenant: 'expedia', env: 'wd108', site: 'search' },
+      limit: 3,
+    });
+    assert.equal(received.ats, 'workday');
+    assert.deepEqual(received.config, { tenant: 'expedia', env: 'wd108', site: 'search' });
+    const env = parse(result);
+    assert.equal(env.status, 'success');
+    assert.equal(env.data.length, 1);
+    assert.equal(env.metadata.workday_override, true);
+    assert.equal(env.metadata.ats, 'workday');
+  });
+
+  test('no workday arg leaves ats and config undefined', async () => {
+    let received;
+    const handler = getFetchJobsHandler({
+      fetchJobs: async (opts) => { received = opts; return []; },
+      findAtsBySlug: async () => 'greenhouse',
+    });
+    const result = await handler({ company: 'stripe' });
+    assert.equal(received.ats, undefined);
+    assert.equal(received.config, undefined);
+    const env = parse(result);
+    assert.equal(env.status, 'success');
+    assert.equal(env.metadata.workday_override, false);
+    assert.equal(env.metadata.ats, 'greenhouse');
+  });
+
+  test('incomplete (whitespace) workday triple -> invalid_args, fetchJobs not called', async () => {
+    let called = false;
+    const handler = getFetchJobsHandler({
+      fetchJobs: async () => { called = true; return []; },
+      findAtsBySlug: async () => null,
+    });
+    const result = await handler({ company: 'x', workday: { tenant: '  ', env: 'wd1', site: 'x' } });
+    assert.equal(called, false);
+    const env = parse(result);
+    assert.equal(env.status, 'error');
+    assert.equal(env.error.code, 'invalid_args');
+  });
+
+  test('library Workday API error with a triple -> ats_unreachable', async () => {
+    const handler = getFetchJobsHandler({
+      fetchJobs: async () => { throw new Error('Workday API error for x (a/b/c): 422'); },
+      findAtsBySlug: async () => null,
+    });
+    const result = await handler({ company: 'x', workday: { tenant: 'a', env: 'b', site: 'c' } });
+    const env = parse(result);
+    assert.equal(env.status, 'error');
+    assert.equal(env.error.code, 'ats_unreachable');
+  });
+
+  test('generic library error without workday still maps to invalid_args', async () => {
+    const handler = getFetchJobsHandler({
+      fetchJobs: async () => { throw new Error('Company slug required'); },
+      findAtsBySlug: async () => null,
+    });
+    const result = await handler({ company: '' });
+    const env = parse(result);
+    assert.equal(env.status, 'error');
+    assert.equal(env.error.code, 'invalid_args');
+  });
+});

--- a/mcp/tools.js
+++ b/mcp/tools.js
@@ -21,7 +21,10 @@ import {
   DETECT_ATS,
 } from './descriptions.js';
 
-export function registerTools(server) {
+export function registerTools(server, deps = {}) {
+  const _fetchJobs = deps.fetchJobs || fetchJobs;
+  const _findAtsBySlug = deps.findAtsBySlug || findAtsBySlug;
+
   server.registerTool(
     'fetch_jobs',
     {
@@ -35,12 +38,37 @@ export function registerTools(server) {
         location_includes: z.array(z.string()).optional().describe('Keep jobs whose location contains any keyword'),
         location_excludes: z.array(z.string()).optional().describe('Drop jobs whose location contains any keyword'),
         limit: z.number().int().positive().optional().describe('Cap results (default 100)'),
+        workday: z
+          .object({
+            tenant: z.string().trim().min(1).describe('Workday tenant, the first URL label, e.g. "expedia"'),
+            env: z.string().trim().min(1).describe('Workday env/datacenter, e.g. "wd108", "wd5"'),
+            site: z.string().trim().min(1).describe('Workday career-site path, e.g. "search", "Cisco_Careers"'),
+          })
+          .strict()
+          .optional()
+          .describe('Override the registry for a Workday board not indexed. Derive all three from the careers URL https://{tenant}.{env}.myworkdayjobs.com/{site}. Never guess these.'),
       },
     },
     async (args) => {
+      let ats;
+      let config;
+      if (args.workday) {
+        const { tenant, env, site } = args.workday;
+        if (!tenant?.trim() || !env?.trim() || !site?.trim()) {
+          return error(
+            ERROR_CODES.INVALID_ARGS,
+            'workday requires all three of {tenant, env, site}. Read them from the careers URL https://{tenant}.{env}.myworkdayjobs.com/{site}.'
+          );
+        }
+        ats = 'workday';
+        config = { tenant, env, site };
+      }
+
       try {
-        const jobs = await fetchJobs({
+        const jobs = await _fetchJobs({
           company: args.company,
+          ats,
+          config,
           titleFilter: args.title_filter,
           filter: args.filter,
           postedWithinDays: args.posted_within_days,
@@ -50,15 +78,23 @@ export function registerTools(server) {
         });
 
         const normalizedSlug = args.company.toLowerCase().replace(/[^a-z0-9]/g, '');
-        const registryAts = await findAtsBySlug(normalizedSlug);
+        const registryAts = await _findAtsBySlug(normalizedSlug);
 
         return success(jobs, {
           count: jobs.length,
           registry_hit: registryAts !== null,
-          ats: registryAts,
+          ats: config ? 'workday' : registryAts,
+          workday_override: Boolean(config),
         });
       } catch (err) {
-        return error(ERROR_CODES.INVALID_ARGS, err.message || 'Unknown error');
+        const msg = err.message || 'Unknown error';
+        if (config && /Workday API error/.test(msg)) {
+          return error(
+            ERROR_CODES.ATS_UNREACHABLE,
+            `Workday rejected ${config.tenant}/${config.env}/${config.site}: ${msg}. Verify the triple against the careers URL https://{tenant}.{env}.myworkdayjobs.com/{site}.`
+          );
+        }
+        return error(ERROR_CODES.INVALID_ARGS, msg);
       }
     }
   );


### PR DESCRIPTION
## Summary
- Adds an optional structured `workday: { tenant, env, site }` argument to the MCP `fetch_jobs` tool, mapping 1:1 to the library `config` and the CLI `--workday-*` flags. Closes the last-surface gap from jd-intel 0.6.0 (library + CLI shipped it; MCP did not).
- `registerTools(server, deps={})` gains a minimal dependency-injection seam (defaults to real deps; zero production behavior change) enabling the project's first automated MCP test.
- Incomplete triple → `invalid_args`; a Workday API failure with a supplied triple → `ats_unreachable`; metadata gains `workday_override`. `descriptions.js` gets a `workday` ARGUMENT GUIDE entry (with a hard "never guess these" instruction) and updated error-code bullets.
- Bumps `jd-intel-mcp` 0.5.0 → 0.6.0 and its `jd-intel` dependency `^0.5.0` → `^0.6.0`.

## Test plan
- [x] `cd mcp && npm install` resolves `jd-intel@0.6.0`
- [x] `mcp` suite: 5/5 new tests green (mapping, no-workday, incomplete→invalid_args, Workday-error→ats_unreachable, generic-error→invalid_args)
- [x] Root suite still 130/130 (no regression)
- [x] Live stdin JSON-RPC smoke against `node mcp/server.js` with the Expedia triple → `status=success count=3 ats=workday workday_override=true`, real job returned
- [x] Voice: `descriptions.js` AI-facing strings + new `tools.js` describe strings em-dash-free

Release: tag `v0.6.0-mcp` after merge → publish.yml publishes `jd-intel-mcp@0.6.0` (jd-intel idempotent-skips). MCP-only release; full mcp-builder audit deferred to #18.