### PR TITLE
feat(registry): +15 live-verified companies across 3 ATS

### DIFF
--- a/docs/registry/ashby.json
+++ b/docs/registry/ashby.json
@@ -45,5 +45,9 @@
   {"slug": "sentry",         "name": "Sentry",         "sector": "observability"},
   {"slug": "cartesia",       "name": "Cartesia",       "sector": "voice ai"},
   {"slug": "workos",         "name": "WorkOS",         "sector": "auth / sso dev tools"},
-  {"slug": "posthog",        "name": "PostHog",        "sector": "product analytics"}
+  {"slug": "posthog",        "name": "PostHog",        "sector": "product analytics"},
+  {"slug": "openevidence",   "name": "OpenEvidence",   "sector": "healthcare ai"},
+  {"slug": "antimetal",      "name": "Antimetal",      "sector": "developer tools"},
+  {"slug": "maintainx",      "name": "MaintainX",      "sector": "industrial saas"},
+  {"slug": "sparrow",        "name": "Sparrow",        "sector": "hr tech"}
 ]

--- a/docs/registry/greenhouse.json
+++ b/docs/registry/greenhouse.json
@@ -50,7 +50,6 @@
   {"slug": "fleetio",               "name": "Fleetio",                 "sector": "fleet management"},
   {"slug": "engine",                "name": "Engine",                  "sector": "travel tech"},
   {"slug": "axon",                  "name": "Axon",                    "sector": "public safety"},
-  {"slug": "sparrow",               "name": "Sparrow",                 "sector": "hr tech"},
   {"slug": "remotecom",             "name": "Remote",                  "sector": "hr tech"},
   {"slug": "weedmaps77",            "name": "Weedmaps",                "sector": "cannabis"},
   {"slug": "patterndata",           "name": "Pattern",                 "sector": "ecommerce data"},
@@ -59,7 +58,6 @@
   {"slug": "eltropyinc",            "name": "Eltropy",                 "sector": "fintech"},
   {"slug": "ziprecruiter",          "name": "ZipRecruiter",            "sector": "recruiting tech"},
   {"slug": "cognitiv",              "name": "Cognitiv",                "sector": "adtech"},
-  {"slug": "maintainx",             "name": "MaintainX",               "sector": "industrial saas"},
   {"slug": "betterhelpcom",         "name": "BetterHelp",              "sector": "mental health"},
   {"slug": "shopmonkey",            "name": "Shopmonkey",              "sector": "automotive saas"},
   {"slug": "ezcaterinc",            "name": "ezCater",                 "sector": "food tech"},
@@ -127,5 +125,15 @@
   {"slug": "modernhealth",          "name": "Modern Health",           "sector": "mental health"},
   {"slug": "bitwarden",             "name": "Bitwarden",               "sector": "security"},
   {"slug": "descript",              "name": "Descript",                "sector": "media tools"},
-  {"slug": "assemblyai",            "name": "AssemblyAI",              "sector": "ai speech"}
+  {"slug": "assemblyai",            "name": "AssemblyAI",              "sector": "ai speech"},
+  {"slug": "coherehealth",          "name": "Cohere Health",           "sector": "healthcare ai"},
+  {"slug": "thirtymadison",         "name": "Thirty Madison",          "sector": "healthcare"},
+  {"slug": "ginkgobioworks",        "name": "Ginkgo Bioworks",         "sector": "biotech"},
+  {"slug": "truveta",               "name": "Truveta",                 "sector": "health data"},
+  {"slug": "komodohealth",          "name": "Komodo Health",           "sector": "health data"},
+  {"slug": "oshihealth",            "name": "Oshi Health",             "sector": "healthcare"},
+  {"slug": "redwoodmaterials",      "name": "Redwood Materials",       "sector": "materials"},
+  {"slug": "antora",                "name": "Antora Energy",           "sector": "energy"},
+  {"slug": "palmetto",              "name": "Palmetto",                "sector": "energy"},
+  {"slug": "rondoenergy",           "name": "Rondo Energy",            "sector": "energy"}
 ]

--- a/docs/registry/recruitee.json
+++ b/docs/registry/recruitee.json
@@ -1,5 +1,4 @@
 [
-  {"slug": "incentro",                "name": "Incentro",                        "sector": "it consultancy"},
   {"slug": "channable",               "name": "Channable",                       "sector": "ecommerce / feed management"},
   {"slug": "vandebron",               "name": "Vandebron",                       "sector": "energy"},
   {"slug": "effectory",               "name": "Effectory",                       "sector": "hr tech"},

--- a/docs/registry/teamtailor.json
+++ b/docs/registry/teamtailor.json
@@ -29,5 +29,9 @@
   {"slug": "finteqhub",                       "name": "FinteqHub",              "sector": "fintech / payments"},
   {"slug": "goodgamestudios",                 "name": "Goodgame Studios",       "sector": "gaming"},
   {"slug": "estonew",                         "name": "ESTO",                   "sector": "fintech / consumer credit"},
-  {"slug": "cigames",                         "name": "CI Games",               "sector": "gaming"}
+  {"slug": "cigames",                         "name": "CI Games",               "sector": "gaming"},
+  {"slug": "ardoq",                           "name": "Ardoq",                  "sector": "enterprise software"},
+  {"slug": "sellpy",                          "name": "Sellpy",                 "sector": "ecommerce"},
+  {"slug": "planhat",                         "name": "Planhat",                "sector": "saas"},
+  {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"}
 ]

--- a/registry/ashby.json
+++ b/registry/ashby.json
@@ -45,5 +45,9 @@
   {"slug": "sentry",         "name": "Sentry",         "sector": "observability"},
   {"slug": "cartesia",       "name": "Cartesia",       "sector": "voice ai"},
   {"slug": "workos",         "name": "WorkOS",         "sector": "auth / sso dev tools"},
-  {"slug": "posthog",        "name": "PostHog",        "sector": "product analytics"}
+  {"slug": "posthog",        "name": "PostHog",        "sector": "product analytics"},
+  {"slug": "openevidence",   "name": "OpenEvidence",   "sector": "healthcare ai"},
+  {"slug": "antimetal",      "name": "Antimetal",      "sector": "developer tools"},
+  {"slug": "maintainx",      "name": "MaintainX",      "sector": "industrial saas"},
+  {"slug": "sparrow",        "name": "Sparrow",        "sector": "hr tech"}
 ]

--- a/registry/greenhouse.json
+++ b/registry/greenhouse.json
@@ -50,7 +50,6 @@
   {"slug": "fleetio",               "name": "Fleetio",                 "sector": "fleet management"},
   {"slug": "engine",                "name": "Engine",                  "sector": "travel tech"},
   {"slug": "axon",                  "name": "Axon",                    "sector": "public safety"},
-  {"slug": "sparrow",               "name": "Sparrow",                 "sector": "hr tech"},
   {"slug": "remotecom",             "name": "Remote",                  "sector": "hr tech"},
   {"slug": "weedmaps77",            "name": "Weedmaps",                "sector": "cannabis"},
   {"slug": "patterndata",           "name": "Pattern",                 "sector": "ecommerce data"},
@@ -59,7 +58,6 @@
   {"slug": "eltropyinc",            "name": "Eltropy",                 "sector": "fintech"},
   {"slug": "ziprecruiter",          "name": "ZipRecruiter",            "sector": "recruiting tech"},
   {"slug": "cognitiv",              "name": "Cognitiv",                "sector": "adtech"},
-  {"slug": "maintainx",             "name": "MaintainX",               "sector": "industrial saas"},
   {"slug": "betterhelpcom",         "name": "BetterHelp",              "sector": "mental health"},
   {"slug": "shopmonkey",            "name": "Shopmonkey",              "sector": "automotive saas"},
   {"slug": "ezcaterinc",            "name": "ezCater",                 "sector": "food tech"},
@@ -127,5 +125,15 @@
   {"slug": "modernhealth",          "name": "Modern Health",           "sector": "mental health"},
   {"slug": "bitwarden",             "name": "Bitwarden",               "sector": "security"},
   {"slug": "descript",              "name": "Descript",                "sector": "media tools"},
-  {"slug": "assemblyai",            "name": "AssemblyAI",              "sector": "ai speech"}
+  {"slug": "assemblyai",            "name": "AssemblyAI",              "sector": "ai speech"},
+  {"slug": "coherehealth",          "name": "Cohere Health",           "sector": "healthcare ai"},
+  {"slug": "thirtymadison",         "name": "Thirty Madison",          "sector": "healthcare"},
+  {"slug": "ginkgobioworks",        "name": "Ginkgo Bioworks",         "sector": "biotech"},
+  {"slug": "truveta",               "name": "Truveta",                 "sector": "health data"},
+  {"slug": "komodohealth",          "name": "Komodo Health",           "sector": "health data"},
+  {"slug": "oshihealth",            "name": "Oshi Health",             "sector": "healthcare"},
+  {"slug": "redwoodmaterials",      "name": "Redwood Materials",       "sector": "materials"},
+  {"slug": "antora",                "name": "Antora Energy",           "sector": "energy"},
+  {"slug": "palmetto",              "name": "Palmetto",                "sector": "energy"},
+  {"slug": "rondoenergy",           "name": "Rondo Energy",            "sector": "energy"}
 ]

--- a/registry/recruitee.json
+++ b/registry/recruitee.json
@@ -1,5 +1,4 @@
 [
-  {"slug": "incentro",                "name": "Incentro",                        "sector": "it consultancy"},
   {"slug": "channable",               "name": "Channable",                       "sector": "ecommerce / feed management"},
   {"slug": "vandebron",               "name": "Vandebron",                       "sector": "energy"},
   {"slug": "effectory",               "name": "Effectory",                       "sector": "hr tech"},

--- a/registry/teamtailor.json
+++ b/registry/teamtailor.json
@@ -29,5 +29,9 @@
   {"slug": "finteqhub",                       "name": "FinteqHub",              "sector": "fintech / payments"},
   {"slug": "goodgamestudios",                 "name": "Goodgame Studios",       "sector": "gaming"},
   {"slug": "estonew",                         "name": "ESTO",                   "sector": "fintech / consumer credit"},
-  {"slug": "cigames",                         "name": "CI Games",               "sector": "gaming"}
+  {"slug": "cigames",                         "name": "CI Games",               "sector": "gaming"},
+  {"slug": "ardoq",                           "name": "Ardoq",                  "sector": "enterprise software"},
+  {"slug": "sellpy",                          "name": "Sellpy",                 "sector": "ecommerce"},
+  {"slug": "planhat",                         "name": "Planhat",                "sector": "saas"},
+  {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"}
 ]


### PR DESCRIPTION
This week's sourcing leaned into three themes plus a top-up on the two smallest registry files: healthcare and biotech (Greenhouse), climate and energy (Greenhouse), and Nordic and European companies (TeamTailor, Recruitee). Every entry below passed the live verify gate (`scripts/verify-registry.mjs --candidates`) in this run.

## Additions

| Company | ATS | Sector | Live jobs |
|---|---|---|---|
| Cohere Health | Greenhouse | healthcare ai | 50+ |
| Thirty Madison | Greenhouse | healthcare | 4 |
| Ginkgo Bioworks | Greenhouse | biotech | 16 |
| Truveta | Greenhouse | health data | 41 |
| Komodo Health | Greenhouse | health data | 40 |
| Oshi Health | Greenhouse | healthcare | 8 |
| Redwood Materials | Greenhouse | materials | 50+ |
| Antora Energy | Greenhouse | energy | 26 |
| Palmetto | Greenhouse | energy | 1 |
| Rondo Energy | Greenhouse | energy | 16 |
| OpenEvidence | Ashby | healthcare ai | 11 |
| Antimetal | Ashby | developer tools | 9 |
| Ardoq | TeamTailor | enterprise software | 4 |
| Sellpy | TeamTailor | ecommerce | 9 |
| Planhat | TeamTailor | saas | 5 |

## Migrations

Each old board returned 404 (gone) on its recorded ATS and live-verified on the new ATS with matching company identity (job titles and locations checked).

| Company | From | To | Live jobs |
|---|---|---|---|
| MaintainX | Greenhouse | Ashby | 50+ |
| Sparrow | Greenhouse | Ashby | 11 |
| Incentro | Recruitee | TeamTailor | 19 |

## Registry health (informational)

Existing entries that came back empty or errored in this run. Left untouched (no qualifying migration found; boards that are live but empty read as a hiring pause, not a move):

- Greenhouse: `merge` (Merge), `dbtlabsinc` (dbt Labs) — boards live, zero open roles at check time
- Recruitee: `sovtech` (Scrums.com) — board 404, no live board found on any other ATS
- TeamTailor: `funnel` (Funnel), `karma` (Karma) empty; `juni` (Juni), `mate` (Mate) unreachable — no migration target found
- Ashby: `clerk` (Clerk) — board live, zero open roles
- Lever: `plaid` (Plaid), `clari` (Clari), `netflix` (Netflix), `lever` (Lever) — boards live, zero open roles
- SmartRecruiters: `BoschGroup`, `linkedin3`, `xplor` — HTTP 429 (rate limit), transient, not treated as failures

No ATS showed systemic failure (all well under the 50% threshold), so no endpoint-drift issue was opened.

## Candidate counts

- 90 expansion candidates pre-probed; 8 skipped as duplicates already in the registry; 17 passed the cheap pre-probe
- 3 migration entries staged alongside them (20 total through the verify gate)
- 18 survived the live gate: 15 additions + 3 migrations. Dropped at the gate: `bokio`, `normative` (TeamTailor boards returned zero parseable postings)

Registry total after this run: 331 entries. Tests: 137 pass.
