### PR TITLE
feat(registry): +24 live-verified companies across 6 ATS

### DIFF
--- a/docs/registry/ashby.json
+++ b/docs/registry/ashby.json
@@ -49,5 +49,10 @@
   {"slug": "openevidence",   "name": "OpenEvidence",   "sector": "healthcare ai"},
   {"slug": "antimetal",      "name": "Antimetal",      "sector": "developer tools"},
   {"slug": "maintainx",      "name": "MaintainX",      "sector": "industrial saas"},
-  {"slug": "sparrow",        "name": "Sparrow",        "sector": "hr tech"}
+  {"slug": "sparrow",        "name": "Sparrow",        "sector": "hr tech"},
+  {"slug": "atlan",          "name": "Atlan",          "sector": "data"},
+  {"slug": "hackerone",      "name": "HackerOne",      "sector": "security"},
+  {"slug": "Speakeasy",      "name": "Speakeasy",      "sector": "dev tools"},
+  {"slug": "enter-ai",       "name": "Enter",          "sector": "fintech"},
+  {"slug": "merge",          "name": "Merge",          "sector": "integration platform"}
 ]

--- a/docs/registry/greenhouse.json
+++ b/docs/registry/greenhouse.json
@@ -30,7 +30,6 @@
   {"slug": "contentful",            "name": "Contentful",              "sector": "cms"},
   {"slug": "sendbird",              "name": "Sendbird",                "sector": "communications"},
   {"slug": "workato",               "name": "Workato",                 "sector": "integration platform"},
-  {"slug": "merge",                 "name": "Merge",                   "sector": "integration platform"},
   {"slug": "pandadoc",              "name": "PandaDoc",                "sector": "sales tech"},
   {"slug": "fivetran",              "name": "Fivetran",                "sector": "data integration"},
   {"slug": "securityscorecard",     "name": "SecurityScorecard",       "sector": "security"},

--- a/docs/registry/lever.json
+++ b/docs/registry/lever.json
@@ -28,5 +28,12 @@
   {"slug": "mulliganfunding", "name": "Mulligan Funding", "sector": "smb lending"},
   {"slug": "immutable",       "name": "Immutable",        "sector": "web3 / blockchain gaming"},
   {"slug": "fundrise",        "name": "Fundrise",         "sector": "real-estate investing"},
-  {"slug": "jobgether",       "name": "Jobgether",        "sector": "recruiting tech"}
+  {"slug": "jobgether",       "name": "Jobgether",        "sector": "recruiting tech"},
+  {"slug": "payjoy",          "name": "PayJoy",           "sector": "fintech"},
+  {"slug": "Flex",            "name": "Flex",             "sector": "fintech"},
+  {"slug": "goodleap",        "name": "GoodLeap",         "sector": "fintech / financing"},
+  {"slug": "startengine",     "name": "StartEngine",      "sector": "fintech"},
+  {"slug": "moonpay",         "name": "MoonPay",          "sector": "fintech / crypto"},
+  {"slug": "angellist",       "name": "AngelList",        "sector": "fintech"},
+  {"slug": "paytm",           "name": "Paytm",            "sector": "fintech / payments"}
 ]

--- a/docs/registry/recruitee.json
+++ b/docs/registry/recruitee.json
@@ -20,5 +20,11 @@
   {"slug": "sovtech",                 "name": "Scrums.com",                      "sector": "software services"},
   {"slug": "technicaengineeringgmbh", "name": "Technica Engineering",            "sector": "automotive engineering"},
   {"slug": "make",                    "name": "Make",                            "sector": "construction / property"},
-  {"slug": "luzmo",                   "name": "Luzmo",                           "sector": "embedded analytics saas"}
+  {"slug": "luzmo",                   "name": "Luzmo",                           "sector": "embedded analytics saas"},
+  {"slug": "hostaway",                "name": "Hostaway",                        "sector": "hospitality tech"},
+  {"slug": "eneve",                   "name": "Eneve",                           "sector": "energy tech"},
+  {"slug": "helloprint",              "name": "Helloprint",                      "sector": "custom manufacturing"},
+  {"slug": "customssupport",          "name": "Customs Support",                 "sector": "logistics"},
+  {"slug": "ibexa",                   "name": "Ibexa",                           "sector": "cms"},
+  {"slug": "framestore",              "name": "Framestore",                      "sector": "media / entertainment"}
 ]

--- a/docs/registry/smartrecruiters.json
+++ b/docs/registry/smartrecruiters.json
@@ -26,5 +26,6 @@
   {"slug": "cityandcountyofsanfrancisco1", "name": "City & County of San Francisco", "sector": "government"},
   {"slug": "DeltaElectronics",             "name": "Delta Electronics",              "sector": "electronics / power"},
   {"slug": "PSLogistics",                  "name": "PS Logistics",                   "sector": "logistics"},
-  {"slug": "OECD",                         "name": "OECD",                           "sector": "intergovernmental"}
+  {"slug": "OECD",                         "name": "OECD",                           "sector": "intergovernmental"},
+  {"slug": "FinaktivaSAS",                 "name": "Finaktiva",                      "sector": "fintech"}
 ]

--- a/docs/registry/teamtailor.json
+++ b/docs/registry/teamtailor.json
@@ -33,5 +33,6 @@
   {"slug": "ardoq",                           "name": "Ardoq",                  "sector": "enterprise software"},
   {"slug": "sellpy",                          "name": "Sellpy",                 "sector": "ecommerce"},
   {"slug": "planhat",                         "name": "Planhat",                "sector": "saas"},
-  {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"}
+  {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"},
+  {"slug": "ictnordics",                      "name": "ICT Nordics",            "sector": "engineering / IT consulting"}
 ]

--- a/docs/registry/workday.json
+++ b/docs/registry/workday.json
@@ -26,5 +26,10 @@
   {"slug": "sonypictures",       "name": "Sony Pictures Entertainment", "sector": "media / entertainment", "config": {"tenant": "spe", "env": "wd1", "site": "SonyPicturesEntertainment"}},
   {"slug": "merative",           "name": "Merative",                    "sector": "health data", "config": {"tenant": "merative", "env": "wd12", "site": "External_Career_Site"}},
   {"slug": "duckcreek",          "name": "Duck Creek Technologies",     "sector": "insurance software", "config": {"tenant": "duckcreek", "env": "wd1", "site": "duckcreekcareers"}},
-  {"slug": "expedia",            "name": "Expedia Group",               "sector": "travel", "config": {"tenant": "expedia", "env": "wd108", "site": "search"}}
+  {"slug": "expedia",            "name": "Expedia Group",               "sector": "travel", "config": {"tenant": "expedia", "env": "wd108", "site": "search"}},
+  {"slug": "workday",            "name": "Workday",                     "sector": "hr tech", "config": {"tenant": "workday", "env": "wd5", "site": "Workday"}},
+  {"slug": "kyndryl",            "name": "Kyndryl",                     "sector": "it services", "config": {"tenant": "kyndryl", "env": "wd5", "site": "KyndrylProfessionalCareers"}},
+  {"slug": "huron",              "name": "Huron Consulting",            "sector": "consulting", "config": {"tenant": "huron", "env": "wd1", "site": "huroncareers"}},
+  {"slug": "nxp",                "name": "NXP Semiconductors",          "sector": "semiconductors", "config": {"tenant": "nxp", "env": "wd3", "site": "careers"}},
+  {"slug": "pwc",                "name": "PwC",                         "sector": "consulting", "config": {"tenant": "pwc", "env": "wd3", "site": "Global_Experienced_Careers"}}
 ]

--- a/registry/ashby.json
+++ b/registry/ashby.json
@@ -49,5 +49,10 @@
   {"slug": "openevidence",   "name": "OpenEvidence",   "sector": "healthcare ai"},
   {"slug": "antimetal",      "name": "Antimetal",      "sector": "developer tools"},
   {"slug": "maintainx",      "name": "MaintainX",      "sector": "industrial saas"},
-  {"slug": "sparrow",        "name": "Sparrow",        "sector": "hr tech"}
+  {"slug": "sparrow",        "name": "Sparrow",        "sector": "hr tech"},
+  {"slug": "atlan",          "name": "Atlan",          "sector": "data"},
+  {"slug": "hackerone",      "name": "HackerOne",      "sector": "security"},
+  {"slug": "Speakeasy",      "name": "Speakeasy",      "sector": "dev tools"},
+  {"slug": "enter-ai",       "name": "Enter",          "sector": "fintech"},
+  {"slug": "merge",          "name": "Merge",          "sector": "integration platform"}
 ]

--- a/registry/greenhouse.json
+++ b/registry/greenhouse.json
@@ -30,7 +30,6 @@
   {"slug": "contentful",            "name": "Contentful",              "sector": "cms"},
   {"slug": "sendbird",              "name": "Sendbird",                "sector": "communications"},
   {"slug": "workato",               "name": "Workato",                 "sector": "integration platform"},
-  {"slug": "merge",                 "name": "Merge",                   "sector": "integration platform"},
   {"slug": "pandadoc",              "name": "PandaDoc",                "sector": "sales tech"},
   {"slug": "fivetran",              "name": "Fivetran",                "sector": "data integration"},
   {"slug": "securityscorecard",     "name": "SecurityScorecard",       "sector": "security"},

--- a/registry/lever.json
+++ b/registry/lever.json
@@ -28,5 +28,12 @@
   {"slug": "mulliganfunding", "name": "Mulligan Funding", "sector": "smb lending"},
   {"slug": "immutable",       "name": "Immutable",        "sector": "web3 / blockchain gaming"},
   {"slug": "fundrise",        "name": "Fundrise",         "sector": "real-estate investing"},
-  {"slug": "jobgether",       "name": "Jobgether",        "sector": "recruiting tech"}
+  {"slug": "jobgether",       "name": "Jobgether",        "sector": "recruiting tech"},
+  {"slug": "payjoy",          "name": "PayJoy",           "sector": "fintech"},
+  {"slug": "Flex",            "name": "Flex",             "sector": "fintech"},
+  {"slug": "goodleap",        "name": "GoodLeap",         "sector": "fintech / financing"},
+  {"slug": "startengine",     "name": "StartEngine",      "sector": "fintech"},
+  {"slug": "moonpay",         "name": "MoonPay",          "sector": "fintech / crypto"},
+  {"slug": "angellist",       "name": "AngelList",        "sector": "fintech"},
+  {"slug": "paytm",           "name": "Paytm",            "sector": "fintech / payments"}
 ]

--- a/registry/recruitee.json
+++ b/registry/recruitee.json
@@ -20,5 +20,11 @@
   {"slug": "sovtech",                 "name": "Scrums.com",                      "sector": "software services"},
   {"slug": "technicaengineeringgmbh", "name": "Technica Engineering",            "sector": "automotive engineering"},
   {"slug": "make",                    "name": "Make",                            "sector": "construction / property"},
-  {"slug": "luzmo",                   "name": "Luzmo",                           "sector": "embedded analytics saas"}
+  {"slug": "luzmo",                   "name": "Luzmo",                           "sector": "embedded analytics saas"},
+  {"slug": "hostaway",                "name": "Hostaway",                        "sector": "hospitality tech"},
+  {"slug": "eneve",                   "name": "Eneve",                           "sector": "energy tech"},
+  {"slug": "helloprint",              "name": "Helloprint",                      "sector": "custom manufacturing"},
+  {"slug": "customssupport",          "name": "Customs Support",                 "sector": "logistics"},
+  {"slug": "ibexa",                   "name": "Ibexa",                           "sector": "cms"},
+  {"slug": "framestore",              "name": "Framestore",                      "sector": "media / entertainment"}
 ]

--- a/registry/smartrecruiters.json
+++ b/registry/smartrecruiters.json
@@ -26,5 +26,6 @@
   {"slug": "cityandcountyofsanfrancisco1", "name": "City & County of San Francisco", "sector": "government"},
   {"slug": "DeltaElectronics",             "name": "Delta Electronics",              "sector": "electronics / power"},
   {"slug": "PSLogistics",                  "name": "PS Logistics",                   "sector": "logistics"},
-  {"slug": "OECD",                         "name": "OECD",                           "sector": "intergovernmental"}
+  {"slug": "OECD",                         "name": "OECD",                           "sector": "intergovernmental"},
+  {"slug": "FinaktivaSAS",                 "name": "Finaktiva",                      "sector": "fintech"}
 ]

--- a/registry/teamtailor.json
+++ b/registry/teamtailor.json
@@ -33,5 +33,6 @@
   {"slug": "ardoq",                           "name": "Ardoq",                  "sector": "enterprise software"},
   {"slug": "sellpy",                          "name": "Sellpy",                 "sector": "ecommerce"},
   {"slug": "planhat",                         "name": "Planhat",                "sector": "saas"},
-  {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"}
+  {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"},
+  {"slug": "ictnordics",                      "name": "ICT Nordics",            "sector": "engineering / IT consulting"}
 ]

--- a/registry/workday.json
+++ b/registry/workday.json
@@ -26,5 +26,10 @@
   {"slug": "sonypictures",       "name": "Sony Pictures Entertainment", "sector": "media / entertainment", "config": {"tenant": "spe", "env": "wd1", "site": "SonyPicturesEntertainment"}},
   {"slug": "merative",           "name": "Merative",                    "sector": "health data", "config": {"tenant": "merative", "env": "wd12", "site": "External_Career_Site"}},
   {"slug": "duckcreek",          "name": "Duck Creek Technologies",     "sector": "insurance software", "config": {"tenant": "duckcreek", "env": "wd1", "site": "duckcreekcareers"}},
-  {"slug": "expedia",            "name": "Expedia Group",               "sector": "travel", "config": {"tenant": "expedia", "env": "wd108", "site": "search"}}
+  {"slug": "expedia",            "name": "Expedia Group",               "sector": "travel", "config": {"tenant": "expedia", "env": "wd108", "site": "search"}},
+  {"slug": "workday",            "name": "Workday",                     "sector": "hr tech", "config": {"tenant": "workday", "env": "wd5", "site": "Workday"}},
+  {"slug": "kyndryl",            "name": "Kyndryl",                     "sector": "it services", "config": {"tenant": "kyndryl", "env": "wd5", "site": "KyndrylProfessionalCareers"}},
+  {"slug": "huron",              "name": "Huron Consulting",            "sector": "consulting", "config": {"tenant": "huron", "env": "wd1", "site": "huroncareers"}},
+  {"slug": "nxp",                "name": "NXP Semiconductors",          "sector": "semiconductors", "config": {"tenant": "nxp", "env": "wd3", "site": "careers"}},
+  {"slug": "pwc",                "name": "PwC",                         "sector": "consulting", "config": {"tenant": "pwc", "env": "wd3", "site": "Global_Experienced_Careers"}}
 ]


### PR DESCRIPTION
This week's sourcing rotated across devtools/security, fintech/payments, European companies (biasing the two smallest files, recruitee and smartrecruiters), and a Workday enterprise-seed pass; every entry below passed the live `verify-registry` gate in this run.

## Additions (24)

| Company | ATS | Sector | Live jobs |
|---|---|---|---|
| Hostaway | recruitee | hospitality tech | 13 |
| Eneve | recruitee | energy tech | 13 |
| Helloprint | recruitee | custom manufacturing | 3 |
| Customs Support | recruitee | logistics | 50+ |
| Ibexa | recruitee | cms | 12 |
| Framestore | recruitee | media / entertainment | 50+ |
| Finaktiva | smartrecruiters | fintech | 3 |
| Atlan | ashby | data | 4 |
| HackerOne | ashby | security | 26 |
| Speakeasy | ashby | dev tools | 5 |
| Enter | ashby | fintech | 10 |
| PayJoy | lever | fintech | 50+ |
| Flex | lever | fintech | 32 |
| GoodLeap | lever | fintech / financing | 23 |
| StartEngine | lever | fintech | 6 |
| MoonPay | lever | fintech / crypto | 9 |
| AngelList | lever | fintech | 22 |
| Paytm | lever | fintech / payments | 50+ |
| ICT Nordics | teamtailor | engineering / IT consulting | 9 |
| Workday | workday | hr tech | 50+ |
| Kyndryl | workday | it services | 50+ |
| Huron Consulting | workday | consulting | 50+ |
| NXP Semiconductors | workday | semiconductors | 50+ |
| PwC | workday | consulting | 50+ |

## Migrations (1)

| Company | From | To | Live jobs |
|---|---|---|---|
| Merge | greenhouse | ashby | 21 |

Merge returned zero postings on its recorded Greenhouse board and live-verified with 21 postings on Ashby, so the entry moved.

## Registry health (informational)

These existing entries returned empty or errored in the whole-registry health check and were re-probed across the other six ATS. Each was left untouched (no migration target found, or the migration was deferred):

- Plaid (lever): empty on Lever, but live on Ashby (113 postings). Migration deferred: a hardcoded test asserts `findAtsBySlug('plaid') === 'lever'` (`test/registry.test.js:80`), which sits outside this job's registry-only file scope. Flagged for the maintainer to migrate and update the test together.
- teamtailor: funnel (empty), juni (fetch error), karma (empty), mate (fetch error), billogram (empty) - no target on other ATS
- ashby: clerk (empty on its own board, 0 postings elsewhere)
- lever: clari, netflix, lever, mistral - all empty on Lever, own boards still live, no other ATS hit
- recruitee: sovtech (empty)
- greenhouse: dbtlabsinc (empty)
- smartrecruiters: BoschGroup (fetch error)

No systemic (>50%) failure on any ATS, so no endpoint-drift issue was opened.

## Candidate accounting

- Staged for the live gate: 26 (24 expansion candidates + 2 migration re-verifications)
- Survivors: 26/26 passed
- Dropped at pre-probe before staging: recruitee/playtestcloud (0 jobs), ashby/protectai (404), teamtailor/scandinaviantech (fetch error)
- Skipped as duplicates: Technica Engineering, Visa, WorkOS, Nordic Knots (already in a registry file)
- Applied: 24 additions + 1 migration (Plaid migration deferred, see health section)
