### PR TITLE
fix(registry): migrate Plaid from Lever to Ashby

### DIFF
--- a/docs/registry/ashby.json
+++ b/docs/registry/ashby.json
@@ -54,5 +54,6 @@
   {"slug": "hackerone",      "name": "HackerOne",      "sector": "security"},
   {"slug": "Speakeasy",      "name": "Speakeasy",      "sector": "dev tools"},
   {"slug": "enter-ai",       "name": "Enter",          "sector": "fintech"},
-  {"slug": "merge",          "name": "Merge",          "sector": "integration platform"}
+  {"slug": "merge",          "name": "Merge",          "sector": "integration platform"},
+  {"slug": "plaid",          "name": "Plaid",          "sector": "fintech"}
 ]

--- a/docs/registry/lever.json
+++ b/docs/registry/lever.json
@@ -2,7 +2,6 @@
   {"slug": "olo",             "name": "Olo",              "sector": "restaurant tech"},
   {"slug": "outreach",        "name": "Outreach",         "sector": "sales tech"},
   {"slug": "whoop",           "name": "WHOOP",            "sector": "wearables"},
-  {"slug": "plaid",           "name": "Plaid",            "sector": "fintech"},
   {"slug": "clari",           "name": "Clari",            "sector": "sales tech"},
   {"slug": "netflix",         "name": "Netflix",          "sector": "media"},
   {"slug": "lever",           "name": "Lever",            "sector": "recruiting tech"},

--- a/registry/ashby.json
+++ b/registry/ashby.json
@@ -54,5 +54,6 @@
   {"slug": "hackerone",      "name": "HackerOne",      "sector": "security"},
   {"slug": "Speakeasy",      "name": "Speakeasy",      "sector": "dev tools"},
   {"slug": "enter-ai",       "name": "Enter",          "sector": "fintech"},
-  {"slug": "merge",          "name": "Merge",          "sector": "integration platform"}
+  {"slug": "merge",          "name": "Merge",          "sector": "integration platform"},
+  {"slug": "plaid",          "name": "Plaid",          "sector": "fintech"}
 ]

--- a/registry/lever.json
+++ b/registry/lever.json
@@ -2,7 +2,6 @@
   {"slug": "olo",             "name": "Olo",              "sector": "restaurant tech"},
   {"slug": "outreach",        "name": "Outreach",         "sector": "sales tech"},
   {"slug": "whoop",           "name": "WHOOP",            "sector": "wearables"},
-  {"slug": "plaid",           "name": "Plaid",            "sector": "fintech"},
   {"slug": "clari",           "name": "Clari",            "sector": "sales tech"},
   {"slug": "netflix",         "name": "Netflix",          "sector": "media"},
   {"slug": "lever",           "name": "Lever",            "sector": "recruiting tech"},

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -77,7 +77,7 @@ describe('findAtsBySlug', () => {
   test('works across all three platforms', async () => {
     assert.equal(await findAtsBySlug('stripe'), 'greenhouse');
     assert.equal(await findAtsBySlug('notion'), 'ashby');
-    assert.equal(await findAtsBySlug('plaid'), 'lever');
+    assert.equal(await findAtsBySlug('plaid'), 'ashby');
   });
 
   test('matches case-insensitively (PascalCase SmartRecruiters slug)', async () => {


### PR DESCRIPTION
Plaid's recorded Lever board returns zero postings; the company is live on Ashby with 113 postings (live-verified in this run via scripts/verify-registry.mjs, jobCount capped at 50 in the report).

The hardcoded routing expectation in test/registry.test.js (findAtsBySlug plaid) was updated from lever to ashby. Suite passes 137/137.

Registry ships via the GitHub Pages copy, so merging updates the live registry with no npm release.

Independent of the weekly expansion PRs; no overlapping lines.