### PR TITLE
test(registry): decouple lookup tests from live registry data

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -35,7 +35,12 @@ async function fetchPlatform(platform) {
 }
 
 async function readPlatform(platform) {
-  const data = await readFile(join(REGISTRY_DIR, `${platform}.json`), 'utf-8');
+  // Resolved at call time like registryBaseUrl(): JD_INTEL_REGISTRY_DIR
+  // points the disk loader at a different directory (test fixtures), so
+  // tests can assert lookup semantics without depending on live registry
+  // content.
+  const dir = process.env.JD_INTEL_REGISTRY_DIR || REGISTRY_DIR;
+  const data = await readFile(join(dir, `${platform}.json`), 'utf-8');
   return JSON.parse(data);
 }
 

--- a/test/fetch-jobs.test.js
+++ b/test/fetch-jobs.test.js
@@ -1,10 +1,14 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import { fetchJobs } from '../src/index.js';
 
 // Force the on-disk registry so the global fetch mocks below only intercept
-// adapter calls, never the (now network-first) registry load.
+// adapter calls, never the (now network-first) registry load. Route the disk
+// loader at the fixture registry so routing assertions are independent of
+// live registry content (companies migrate ATS; tests must not care).
 process.env.JD_INTEL_REGISTRY_URL = '';
+process.env.JD_INTEL_REGISTRY_DIR = fileURLToPath(new URL('./fixtures/registry', import.meta.url));
 
 /**
  * fetchJobs routing: explicit-ATS config passthrough (Workday reachable
@@ -50,10 +54,10 @@ describe('fetchJobs — Workday config passthrough', () => {
 
   test('explicit ats=workday with NO config falls back to registry config', async (t) => {
     const calls = workdayMock(t);
-    const jobs = await fetchJobs({ company: 'cisco', ats: 'workday' });
+    const jobs = await fetchJobs({ company: 'fixtureco', ats: 'workday' });
     assert.equal(jobs.length, 1);
     assert.ok(
-      calls.urls.includes('https://cisco.wd5.myworkdayjobs.com/wday/cxs/cisco/Cisco_Careers/jobs'),
+      calls.urls.includes('https://fixtureco.wd0.myworkdayjobs.com/wday/cxs/fixtureco/FixtureCareers/jobs'),
       `expected registry-fallback triple, got: ${calls.urls[0]}`
     );
   });
@@ -61,7 +65,7 @@ describe('fetchJobs — Workday config passthrough', () => {
   test('explicit config overrides the registry entry', async (t) => {
     const calls = workdayMock(t);
     await fetchJobs({
-      company: 'cisco',
+      company: 'fixtureco',
       ats: 'workday',
       config: { tenant: 'override', env: 'wd99', site: 'OverrideSite' },
     });
@@ -70,7 +74,7 @@ describe('fetchJobs — Workday config passthrough', () => {
       `expected explicit config to win, got: ${calls.urls[0]}`
     );
     assert.ok(
-      !calls.urls.some(u => u.includes('cisco.wd5')),
+      !calls.urls.some(u => u.includes('fixtureco.wd0')),
       'registry config must not be used when explicit config is given'
     );
   });
@@ -83,17 +87,17 @@ describe('fetchJobs — canonical-cased registry slug routing', () => {
       calls.urls.push(String(url));
       return { ok: true, status: 200, json: async () => ({ content: [], totalFound: 0 }) };
     });
-    const jobs = await fetchJobs({ company: 'visa' }); // no ats -> registry-routed
+    const jobs = await fetchJobs({ company: 'acmepay' }); // no ats -> registry-routed
     assert.deepEqual(jobs, []);
     // Routed via the registry to a single adapter using the canonical
-    // 'Visa' (not lowercased 'visa', not 7-adapter discovery probing).
+    // 'AcmePay' (not lowercased 'acmepay', not 7-adapter discovery probing).
     assert.ok(
       calls.urls.length > 0 && calls.urls.every(u => u.includes('api.smartrecruiters.com')),
       `expected only SmartRecruiters calls (registry-routed), got: ${calls.urls.join(', ')}`
     );
     assert.ok(
-      calls.urls.some(u => u.includes('/v1/companies/Visa/postings')),
-      `expected canonical 'Visa' in the URL, got: ${calls.urls[0]}`
+      calls.urls.some(u => u.includes('/v1/companies/AcmePay/postings')),
+      `expected canonical 'AcmePay' in the URL, got: ${calls.urls[0]}`
     );
   });
 });

--- a/test/fixtures/registry/ashby.json
+++ b/test/fixtures/registry/ashby.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "fixture-ashby", "name": "Fixture Ashby Co", "sector": "fixtures"}
+]

--- a/test/fixtures/registry/greenhouse.json
+++ b/test/fixtures/registry/greenhouse.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "fixture-gh", "name": "Fixture Greenhouse Co", "sector": "fixtures"}
+]

--- a/test/fixtures/registry/lever.json
+++ b/test/fixtures/registry/lever.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "fixture-lever", "name": "Fixture Lever Co", "sector": "fixtures"}
+]

--- a/test/fixtures/registry/recruitee.json
+++ b/test/fixtures/registry/recruitee.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "fixture-recruitee", "name": "Fixture Recruitee Co", "sector": "fixtures"}
+]

--- a/test/fixtures/registry/smartrecruiters.json
+++ b/test/fixtures/registry/smartrecruiters.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "AcmePay", "name": "AcmePay", "sector": "fixtures"}
+]

--- a/test/fixtures/registry/teamtailor.json
+++ b/test/fixtures/registry/teamtailor.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "fixture-tt", "name": "Fixture TeamTailor Co", "sector": "fixtures"}
+]

--- a/test/fixtures/registry/workday.json
+++ b/test/fixtures/registry/workday.json
@@ -1,0 +1,3 @@
+[
+  {"slug": "fixtureco", "name": "Fixture Workday Co", "sector": "fixtures", "config": {"tenant": "fixtureco", "env": "wd0", "site": "FixtureCareers"}}
+]

--- a/test/registry-data.test.js
+++ b/test/registry-data.test.js
@@ -1,0 +1,83 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+// Integrity invariants over the REAL registry/*.json data. Deliberately
+// content-independent: no specific company is named, so additions, removals,
+// and ATS migrations never break this suite (lookup semantics are covered
+// by registry.test.js against fixtures). Reads the files directly so no
+// loader cache or env override is involved.
+
+const PLATFORMS = ['greenhouse', 'lever', 'ashby', 'smartrecruiters', 'teamtailor', 'recruitee', 'workday'];
+
+// Same normalization as findAtsBySlug in src/registry.js.
+const norm = (s) => String(s).toLowerCase().replace(/[^a-z0-9]/g, '');
+
+async function readRegistry(platform) {
+  const raw = await readFile(new URL(`../registry/${platform}.json`, import.meta.url), 'utf-8');
+  return JSON.parse(raw);
+}
+
+describe('registry data integrity', () => {
+  test('every platform file parses to a non-empty array', async () => {
+    for (const p of PLATFORMS) {
+      const entries = await readRegistry(p);
+      assert.ok(Array.isArray(entries), `${p}.json should be an array`);
+      assert.ok(entries.length > 0, `${p}.json should not be empty`);
+    }
+  });
+
+  test('every entry has non-empty slug, name, and sector', async () => {
+    for (const p of PLATFORMS) {
+      for (const e of await readRegistry(p)) {
+        for (const field of ['slug', 'name', 'sector']) {
+          assert.ok(
+            typeof e[field] === 'string' && e[field].length > 0,
+            `${p}/${e.slug || '?'}: missing or empty ${field}`
+          );
+        }
+      }
+    }
+  });
+
+  test('workday entries have a complete config triple; no other platform has config', async () => {
+    for (const p of PLATFORMS) {
+      for (const e of await readRegistry(p)) {
+        if (p === 'workday') {
+          for (const key of ['tenant', 'env', 'site']) {
+            assert.ok(
+              e.config && typeof e.config[key] === 'string' && e.config[key].length > 0,
+              `workday/${e.slug}: config.${key} missing or empty`
+            );
+          }
+        } else {
+          assert.equal(e.config, undefined, `${p}/${e.slug}: config is Workday-only`);
+        }
+      }
+    }
+  });
+
+  test('no duplicate normalized slug or name across platforms (one company, one ATS)', async () => {
+    const slugs = new Map(); // norm(slug) -> "platform/slug"
+    const names = new Map(); // norm(name) -> "platform/slug"
+    for (const p of PLATFORMS) {
+      for (const e of await readRegistry(p)) {
+        const where = `${p}/${e.slug}`;
+        const s = norm(e.slug);
+        const n = norm(e.name);
+        assert.ok(!slugs.has(s), `duplicate slug: ${where} collides with ${slugs.get(s)}`);
+        assert.ok(!names.has(n), `duplicate name: ${where} collides with ${names.get(n)}`);
+        slugs.set(s, where);
+        names.set(n, where);
+      }
+    }
+  });
+
+  test('docs/registry/ (the hosted Pages copy) is byte-identical to registry/', async () => {
+    for (const p of PLATFORMS) {
+      const source = await readFile(new URL(`../registry/${p}.json`, import.meta.url), 'utf-8');
+      const pages = await readFile(new URL(`../docs/registry/${p}.json`, import.meta.url), 'utf-8');
+      assert.equal(pages, source, `docs/registry/${p}.json is out of sync; run: npm run sync:registry-pages`);
+    }
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -1,11 +1,15 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import { loadRegistry, searchRegistry, findAtsBySlug, findEntryBySlug } from '../src/registry.js';
 
-// Force the on-disk registry: these assertions are against the bundled
-// snapshot, not whatever the hosted copy happens to serve, and must not
-// depend on the network. (Registry is network-first by default.)
+// Registry lookup semantics are asserted against the fixture registry in
+// test/fixtures/registry/, not live data, so company additions, removals,
+// and ATS migrations never break this suite. Both env vars resolve at call
+// time: network path disabled, disk loader pointed at the fixtures. Real
+// registry data integrity lives in registry-data.test.js.
 process.env.JD_INTEL_REGISTRY_URL = '';
+process.env.JD_INTEL_REGISTRY_DIR = fileURLToPath(new URL('./fixtures/registry', import.meta.url));
 
 const ATS_KEYS = ['greenhouse', 'lever', 'ashby', 'smartrecruiters', 'teamtailor', 'recruitee', 'workday'];
 
@@ -13,7 +17,7 @@ describe('loadRegistry', () => {
   test('loads a single ATS as an array', async () => {
     const companies = await loadRegistry('greenhouse');
     assert.ok(Array.isArray(companies), 'should return an array');
-    assert.ok(companies.length > 0, 'greenhouse registry should not be empty');
+    assert.ok(companies.length > 0, 'greenhouse fixture should not be empty');
   });
 
   test('each entry has slug and name', async () => {
@@ -33,7 +37,7 @@ describe('loadRegistry', () => {
     const all = await loadRegistry();
     // Locks the loadRegistry bugfix: every registered ATS must be loaded,
     // not just the original three. Pre-0.5.0 this only loaded
-    // greenhouse/lever/ashby, so ~37 smartrecruiters/teamtailor/recruitee
+    // greenhouse/lever/ashby, so smartrecruiters/teamtailor/recruitee
     // companies fell through to slow discovery probing and never appeared
     // in search_registry; workday's registry-only routing also needs this.
     for (const ats of ATS_KEYS) {
@@ -74,18 +78,19 @@ describe('findAtsBySlug', () => {
     assert.equal(ats, 'greenhouse');
   });
 
-  test('works across all three platforms', async () => {
-    assert.equal(await findAtsBySlug('stripe'), 'greenhouse');
-    assert.equal(await findAtsBySlug('notion'), 'ashby');
-    assert.equal(await findAtsBySlug('plaid'), 'ashby');
+  test('routes slugs to their platforms', async () => {
+    assert.equal(await findAtsBySlug('fixture-gh'), 'greenhouse');
+    assert.equal(await findAtsBySlug('fixture-ashby'), 'ashby');
+    assert.equal(await findAtsBySlug('fixture-lever'), 'lever');
   });
 
   test('matches case-insensitively (PascalCase SmartRecruiters slug)', async () => {
-    // Registry stores "Visa"; callers pass a lowercased/stripped slug.
-    // Pre-fix this returned null and every SR company missed registry
-    // routing (fell through to slow 7-adapter discovery probing).
-    assert.equal(await findAtsBySlug('visa'), 'smartrecruiters');
-    assert.equal(await findAtsBySlug('VISA'), 'smartrecruiters');
+    // Registry stores "AcmePay"; callers pass a lowercased/stripped slug.
+    // Pre-fix this returned null and every SR company (canonical PascalCase
+    // slugs) missed registry routing (fell through to slow 7-adapter
+    // discovery probing).
+    assert.equal(await findAtsBySlug('acmepay'), 'smartrecruiters');
+    assert.equal(await findAtsBySlug('ACMEPAY'), 'smartrecruiters');
   });
 
   test('returns null for unknown slug', async () => {
@@ -96,26 +101,26 @@ describe('findAtsBySlug', () => {
 
 describe('findEntryBySlug', () => {
   test('returns {ats, entry} with adapter config for a Workday slug', async () => {
-    const hit = await findEntryBySlug('cisco');
-    assert.ok(hit, 'cisco should be in the registry');
+    const hit = await findEntryBySlug('fixtureco');
+    assert.ok(hit, 'fixtureco should be in the fixture registry');
     assert.equal(hit.ats, 'workday');
-    assert.equal(hit.entry.slug, 'cisco');
-    assert.equal(hit.entry.name, 'Cisco');
-    assert.deepEqual(hit.entry.config, { tenant: 'cisco', env: 'wd5', site: 'Cisco_Careers' });
+    assert.equal(hit.entry.slug, 'fixtureco');
+    assert.equal(hit.entry.name, 'Fixture Workday Co');
+    assert.deepEqual(hit.entry.config, { tenant: 'fixtureco', env: 'wd0', site: 'FixtureCareers' });
   });
 
   test('returns the full entry for a non-Workday slug', async () => {
-    const hit = await findEntryBySlug('stripe');
+    const hit = await findEntryBySlug('fixture-gh');
     assert.ok(hit);
     assert.equal(hit.ats, 'greenhouse');
-    assert.equal(hit.entry.slug, 'stripe');
+    assert.equal(hit.entry.slug, 'fixture-gh');
   });
 
   test('resolves a PascalCase slug from lowercase and returns canonical casing', async () => {
-    const hit = await findEntryBySlug('visa');
-    assert.ok(hit, 'Visa should resolve from "visa"');
+    const hit = await findEntryBySlug('acmepay');
+    assert.ok(hit, 'AcmePay should resolve from "acmepay"');
     assert.equal(hit.ats, 'smartrecruiters');
-    assert.equal(hit.entry.slug, 'Visa'); // canonical, not the lowercased input
+    assert.equal(hit.entry.slug, 'AcmePay'); // canonical, not the lowercased input
   });
 
   test('returns null for unknown slug', async () => {


### PR DESCRIPTION
The weekly registry expansion deferred the Plaid migration (PR #33) because a test hardcoded which ATS Plaid lives on. Registry data changes weekly by design, so tests must not assert specific companies' platforms.

What changed:
- src/registry.js: JD_INTEL_REGISTRY_DIR resolves at call time (mirrors JD_INTEL_REGISTRY_URL); default behavior unchanged, no public API change.
- test/fixtures/registry/: seven small fixture files covering the lookup semantics (PascalCase SmartRecruiters slug, Workday config triple).
- test/registry.test.js and test/fetch-jobs.test.js now assert routing and casing semantics against fixtures. No real company names remain in behavior assertions.
- test/registry-data.test.js (new): invariants over the real registry that hold regardless of which companies are present: shape (slug/name/sector), complete Workday config triples, no duplicate normalized slug or name across platforms, and docs/registry/ byte-identical to registry/.

Verified: full suite 142/142; a deliberately planted duplicate is caught by the new invariant test; findAtsBySlug('plaid') still resolves to ashby against the real registry with the seam at its default.

No version bump or npm publish; the seam ships with the next regular release.