### PR TITLE
feat(registry): +21 live-verified companies across 6 ATS

### DIFF
--- a/docs/registry/ashby.json
+++ b/docs/registry/ashby.json
@@ -57,5 +57,17 @@
   {"slug": "merge",          "name": "Merge",          "sector": "integration platform"},
   {"slug": "plaid",          "name": "Plaid",          "sector": "fintech"},
   {"slug": "modal",          "name": "Modal",          "sector": "ai data"},
-  {"slug": "planhat",        "name": "Planhat",        "sector": "saas"}
+  {"slug": "planhat",        "name": "Planhat",        "sector": "saas"},
+  {"slug": "semgrep",        "name": "Semgrep",        "sector": "security"},
+  {"slug": "1password",      "name": "1Password",      "sector": "security"},
+  {"slug": "rula",           "name": "Rula",           "sector": "mental health"},
+  {"slug": "zed",            "name": "Zed",            "sector": "dev tools"},
+  {"slug": "oso",            "name": "Oso",            "sector": "auth / sso dev tools"},
+  {"slug": "mux",            "name": "Mux",            "sector": "video saas"},
+  {"slug": "pinecone",       "name": "Pinecone",       "sector": "database"},
+  {"slug": "langchain",      "name": "LangChain",      "sector": "ai dev tools"},
+  {"slug": "inngest",        "name": "Inngest",        "sector": "dev tools"},
+  {"slug": "cryptio",        "name": "Cryptio",        "sector": "fintech / crypto"},
+  {"slug": "pleo",           "name": "Pleo",           "sector": "fintech / corporate cards"},
+  {"slug": "nubank",         "name": "Nubank",         "sector": "fintech"}
 ]

--- a/docs/registry/greenhouse.json
+++ b/docs/registry/greenhouse.json
@@ -89,7 +89,6 @@
   {"slug": "postman",               "name": "Postman",                 "sector": "dev tools"},
   {"slug": "sofi",                  "name": "SoFi",                    "sector": "fintech"},
   {"slug": "smartsheet",            "name": "Smartsheet",              "sector": "productivity"},
-  {"slug": "nubank",                "name": "Nubank",                  "sector": "fintech"},
   {"slug": "flexport",              "name": "Flexport",                "sector": "logistics tech"},
   {"slug": "coinbase",              "name": "Coinbase",                "sector": "fintech / crypto"},
   {"slug": "grafanalabs",           "name": "Grafana Labs",            "sector": "observability"},
@@ -136,5 +135,8 @@
   {"slug": "palmetto",              "name": "Palmetto",                "sector": "energy"},
   {"slug": "rondoenergy",           "name": "Rondo Energy",            "sector": "energy"},
   {"slug": "formationbio",          "name": "Formation Bio",           "sector": "biotech"},
-  {"slug": "isomorphiclabs",        "name": "Isomorphic Labs",         "sector": "biotech"}
+  {"slug": "isomorphiclabs",        "name": "Isomorphic Labs",         "sector": "biotech"},
+  {"slug": "chainguard",            "name": "Chainguard",              "sector": "security"},
+  {"slug": "truecaller",            "name": "Truecaller",              "sector": "communications"},
+  {"slug": "cognite",               "name": "Cognite",                 "sector": "energy tech"}
 ]

--- a/docs/registry/recruitee.json
+++ b/docs/registry/recruitee.json
@@ -33,5 +33,6 @@
   {"slug": "tmnl",                     "name": "TMNL",                            "sector": "fintech"},
   {"slug": "tradinorganic",            "name": "Tradin Organic",                  "sector": "food tech"},
   {"slug": "itilitybv",                "name": "Itility",                         "sector": "it services"},
-  {"slug": "jobsdeerns",               "name": "Deerns",                          "sector": "consulting"}
+  {"slug": "jobsdeerns",               "name": "Deerns",                          "sector": "consulting"},
+  {"slug": "bunq",                     "name": "bunq",                            "sector": "fintech (banking)"}
 ]

--- a/docs/registry/smartrecruiters.json
+++ b/docs/registry/smartrecruiters.json
@@ -32,5 +32,7 @@
   {"slug": "Sandisk",                      "name": "SanDisk",                        "sector": "semiconductors"},
   {"slug": "PilotCompany",                 "name": "Pilot Company",                  "sector": "retail"},
   {"slug": "FLINTCorp1",                   "name": "FLINT Corp",                     "sector": "energy"},
-  {"slug": "Equus",                        "name": "Equus",                          "sector": "it services"}
+  {"slug": "Equus",                        "name": "Equus",                          "sector": "it services"},
+  {"slug": "ubisoft2",                     "name": "Ubisoft",                        "sector": "gaming"},
+  {"slug": "EpochGames",                   "name": "Epoch Games",                    "sector": "gaming"}
 ]

--- a/docs/registry/teamtailor.json
+++ b/docs/registry/teamtailor.json
@@ -33,5 +33,8 @@
   {"slug": "ardoq",                           "name": "Ardoq",                  "sector": "enterprise software"},
   {"slug": "sellpy",                          "name": "Sellpy",                 "sector": "ecommerce"},
   {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"},
-  {"slug": "ictnordics",                      "name": "ICT Nordics",            "sector": "engineering / IT consulting"}
+  {"slug": "ictnordics",                      "name": "ICT Nordics",            "sector": "engineering / IT consulting"},
+  {"slug": "lunar",                           "name": "Lunar",                  "sector": "fintech (banking)"},
+  {"slug": "templafy",                        "name": "Templafy",               "sector": "enterprise software"},
+  {"slug": "vipps",                           "name": "Vipps MobilePay",        "sector": "fintech / payments"}
 ]

--- a/docs/registry/workday.json
+++ b/docs/registry/workday.json
@@ -31,5 +31,6 @@
   {"slug": "kyndryl",            "name": "Kyndryl",                     "sector": "it services", "config": {"tenant": "kyndryl", "env": "wd5", "site": "KyndrylProfessionalCareers"}},
   {"slug": "huron",              "name": "Huron Consulting",            "sector": "consulting", "config": {"tenant": "huron", "env": "wd1", "site": "huroncareers"}},
   {"slug": "nxp",                "name": "NXP Semiconductors",          "sector": "semiconductors", "config": {"tenant": "nxp", "env": "wd3", "site": "careers"}},
-  {"slug": "pwc",                "name": "PwC",                         "sector": "consulting", "config": {"tenant": "pwc", "env": "wd3", "site": "Global_Experienced_Careers"}}
+  {"slug": "pwc",                "name": "PwC",                         "sector": "consulting", "config": {"tenant": "pwc", "env": "wd3", "site": "Global_Experienced_Careers"}},
+  {"slug": "deutschebank",       "name": "Deutsche Bank",               "sector": "banking", "config": {"tenant": "db", "env": "wd3", "site": "DBWebsite"}}
 ]

--- a/registry/ashby.json
+++ b/registry/ashby.json
@@ -57,5 +57,17 @@
   {"slug": "merge",          "name": "Merge",          "sector": "integration platform"},
   {"slug": "plaid",          "name": "Plaid",          "sector": "fintech"},
   {"slug": "modal",          "name": "Modal",          "sector": "ai data"},
-  {"slug": "planhat",        "name": "Planhat",        "sector": "saas"}
+  {"slug": "planhat",        "name": "Planhat",        "sector": "saas"},
+  {"slug": "semgrep",        "name": "Semgrep",        "sector": "security"},
+  {"slug": "1password",      "name": "1Password",      "sector": "security"},
+  {"slug": "rula",           "name": "Rula",           "sector": "mental health"},
+  {"slug": "zed",            "name": "Zed",            "sector": "dev tools"},
+  {"slug": "oso",            "name": "Oso",            "sector": "auth / sso dev tools"},
+  {"slug": "mux",            "name": "Mux",            "sector": "video saas"},
+  {"slug": "pinecone",       "name": "Pinecone",       "sector": "database"},
+  {"slug": "langchain",      "name": "LangChain",      "sector": "ai dev tools"},
+  {"slug": "inngest",        "name": "Inngest",        "sector": "dev tools"},
+  {"slug": "cryptio",        "name": "Cryptio",        "sector": "fintech / crypto"},
+  {"slug": "pleo",           "name": "Pleo",           "sector": "fintech / corporate cards"},
+  {"slug": "nubank",         "name": "Nubank",         "sector": "fintech"}
 ]

--- a/registry/greenhouse.json
+++ b/registry/greenhouse.json
@@ -89,7 +89,6 @@
   {"slug": "postman",               "name": "Postman",                 "sector": "dev tools"},
   {"slug": "sofi",                  "name": "SoFi",                    "sector": "fintech"},
   {"slug": "smartsheet",            "name": "Smartsheet",              "sector": "productivity"},
-  {"slug": "nubank",                "name": "Nubank",                  "sector": "fintech"},
   {"slug": "flexport",              "name": "Flexport",                "sector": "logistics tech"},
   {"slug": "coinbase",              "name": "Coinbase",                "sector": "fintech / crypto"},
   {"slug": "grafanalabs",           "name": "Grafana Labs",            "sector": "observability"},
@@ -136,5 +135,8 @@
   {"slug": "palmetto",              "name": "Palmetto",                "sector": "energy"},
   {"slug": "rondoenergy",           "name": "Rondo Energy",            "sector": "energy"},
   {"slug": "formationbio",          "name": "Formation Bio",           "sector": "biotech"},
-  {"slug": "isomorphiclabs",        "name": "Isomorphic Labs",         "sector": "biotech"}
+  {"slug": "isomorphiclabs",        "name": "Isomorphic Labs",         "sector": "biotech"},
+  {"slug": "chainguard",            "name": "Chainguard",              "sector": "security"},
+  {"slug": "truecaller",            "name": "Truecaller",              "sector": "communications"},
+  {"slug": "cognite",               "name": "Cognite",                 "sector": "energy tech"}
 ]

--- a/registry/recruitee.json
+++ b/registry/recruitee.json
@@ -33,5 +33,6 @@
   {"slug": "tmnl",                     "name": "TMNL",                            "sector": "fintech"},
   {"slug": "tradinorganic",            "name": "Tradin Organic",                  "sector": "food tech"},
   {"slug": "itilitybv",                "name": "Itility",                         "sector": "it services"},
-  {"slug": "jobsdeerns",               "name": "Deerns",                          "sector": "consulting"}
+  {"slug": "jobsdeerns",               "name": "Deerns",                          "sector": "consulting"},
+  {"slug": "bunq",                     "name": "bunq",                            "sector": "fintech (banking)"}
 ]

--- a/registry/smartrecruiters.json
+++ b/registry/smartrecruiters.json
@@ -32,5 +32,7 @@
   {"slug": "Sandisk",                      "name": "SanDisk",                        "sector": "semiconductors"},
   {"slug": "PilotCompany",                 "name": "Pilot Company",                  "sector": "retail"},
   {"slug": "FLINTCorp1",                   "name": "FLINT Corp",                     "sector": "energy"},
-  {"slug": "Equus",                        "name": "Equus",                          "sector": "it services"}
+  {"slug": "Equus",                        "name": "Equus",                          "sector": "it services"},
+  {"slug": "ubisoft2",                     "name": "Ubisoft",                        "sector": "gaming"},
+  {"slug": "EpochGames",                   "name": "Epoch Games",                    "sector": "gaming"}
 ]

--- a/registry/teamtailor.json
+++ b/registry/teamtailor.json
@@ -33,5 +33,8 @@
   {"slug": "ardoq",                           "name": "Ardoq",                  "sector": "enterprise software"},
   {"slug": "sellpy",                          "name": "Sellpy",                 "sector": "ecommerce"},
   {"slug": "incentro",                        "name": "Incentro",               "sector": "it consultancy"},
-  {"slug": "ictnordics",                      "name": "ICT Nordics",            "sector": "engineering / IT consulting"}
+  {"slug": "ictnordics",                      "name": "ICT Nordics",            "sector": "engineering / IT consulting"},
+  {"slug": "lunar",                           "name": "Lunar",                  "sector": "fintech (banking)"},
+  {"slug": "templafy",                        "name": "Templafy",               "sector": "enterprise software"},
+  {"slug": "vipps",                           "name": "Vipps MobilePay",        "sector": "fintech / payments"}
 ]

--- a/registry/workday.json
+++ b/registry/workday.json
@@ -31,5 +31,6 @@
   {"slug": "kyndryl",            "name": "Kyndryl",                     "sector": "it services", "config": {"tenant": "kyndryl", "env": "wd5", "site": "KyndrylProfessionalCareers"}},
   {"slug": "huron",              "name": "Huron Consulting",            "sector": "consulting", "config": {"tenant": "huron", "env": "wd1", "site": "huroncareers"}},
   {"slug": "nxp",                "name": "NXP Semiconductors",          "sector": "semiconductors", "config": {"tenant": "nxp", "env": "wd3", "site": "careers"}},
-  {"slug": "pwc",                "name": "PwC",                         "sector": "consulting", "config": {"tenant": "pwc", "env": "wd3", "site": "Global_Experienced_Careers"}}
+  {"slug": "pwc",                "name": "PwC",                         "sector": "consulting", "config": {"tenant": "pwc", "env": "wd3", "site": "Global_Experienced_Careers"}},
+  {"slug": "deutschebank",       "name": "Deutsche Bank",               "sector": "banking", "config": {"tenant": "db", "env": "wd3", "site": "DBWebsite"}}
 ]


### PR DESCRIPTION
This week's sourcing focused on devtools, infrastructure and security, plus consumer and gaming, with a top-up pass on the two smallest registry files (recruitee, smartrecruiters). Every entry below passed the live gate (`node scripts/verify-registry.mjs --candidates`) in this run.

## Additions

| Company | ATS | Sector | Live jobs |
|---|---|---|---|
| 1Password | Ashby | security | 66 |
| Semgrep | Ashby | security | 19 |
| Rula | Ashby | mental health | 33 |
| Zed | Ashby | dev tools | 2 |
| Oso | Ashby | auth / sso dev tools | 7 |
| Mux | Ashby | video saas | 2 |
| Pinecone | Ashby | database | 5 |
| LangChain | Ashby | ai dev tools | 85 |
| Inngest | Ashby | dev tools | 1 |
| Cryptio | Ashby | fintech / crypto | 3 |
| Pleo | Ashby | fintech / corporate cards | 44 |
| Chainguard | Greenhouse | security | 74 |
| Truecaller | Greenhouse | communications | 21 |
| Cognite | Greenhouse | energy tech | 44 |
| Ubisoft | SmartRecruiters | gaming | 260 |
| Epoch Games | SmartRecruiters | gaming | 8 |
| Lunar | TeamTailor | fintech (banking) | 5 |
| Templafy | TeamTailor | enterprise software | 3 |
| Vipps MobilePay | TeamTailor | fintech / payments | 7 |
| bunq | Recruitee | fintech (banking) | 20 |
| Deutsche Bank | Workday | banking | 40 |

## Migrations

| Company | From | To | Live jobs |
|---|---|---|---|
| Nubank | Greenhouse | Ashby | 97 |

Nubank returned empty on its recorded Greenhouse board in this run's health check and live-verified on Ashby, so the entry moved.

## Registry health (informational)

The full-registry check ran 355 entries: 334 ok, 21 empty or error. No ATS crossed the 50 percent failure line, so no endpoint drift issue was opened. These existing entries came back empty or error and were left untouched:

- Ashby: clerk
- TeamTailor: funnel, karma, billogram (empty); juni, mate, planhat (fetch failed)
- Recruitee: sovtech
- SmartRecruiters: BoschGroup, cityandcountyofsanfrancisco1 (both HTTP 429, transient rate limit)
- Lever: clari, netflix, lever, LuminDigital, mistral, cloudwalk, mulliganfunding
- Greenhouse: houseaccount, dbtlabsinc, thirtymadison

Re-probing these across the other six ATS found no new home for any of them except Nubank. Most still resolve on their recorded ATS with zero current openings, which reads as a hiring pause rather than a move.

## Candidate counts

Staged for verification: 22. Passed: 22. Dropped before staging: 14, for these reasons:

- Ambiguous slug ownership (the same slug resolves to different companies across boards, unsafe for a public registry): warp, knock, neon
- Zero live jobs at probe time: snyk, Skechers1, and several SmartRecruiters slug guesses (McDonalds, IKEA, SquareEnix, Kaufland, MarleySpoon, Getir, WildlifeStudios)
- No board found on any supported ATS: replicate, turso, unkey, cerbos, census, liveblocks, wandb, tigris, voi, einride, kahoot
- Already present in the registry or in an open registry PR: decagon, workos, nxp, salesforce, cisco, Booz Allen Hamilton, tibber

Registry total after this PR: 376 entries. That does not cross the next claimed hundreds boundary, so no count claims in README, docs or CLAUDE.md were touched.

Tests: 142 pass. Pages copy synced via `npm run sync:registry-pages`.
