### PR TITLE
feat(site): add changelog page, update count claims to 500+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ A toolkit (three surfaces, one core) for fetching and normalizing job descriptio
 - **CLI** (`npx jd-intel fetch <slug>`) — same capabilities from the terminal.
 - **MCP server** (`jd-intel-mcp`) — exposes the toolkit to AI assistants via the Model Context Protocol.
 
-Seven ATS adapters shipped: Greenhouse, Lever, Ashby, SmartRecruiters, TeamTailor, Recruitee, Workday. 300+ company verified registry.
+Seven ATS adapters shipped: Greenhouse, Lever, Ashby, SmartRecruiters, TeamTailor, Recruitee, Workday. 500+ company verified registry.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ A toolkit (three surfaces, one core) for fetching and normalizing job descriptio
 - **CLI** (`npx jd-intel fetch <slug>`) — same capabilities from the terminal.
 - **MCP server** (`jd-intel-mcp`) — exposes the toolkit to AI assistants via the Model Context Protocol.
 
-Seven ATS adapters shipped: Greenhouse, Lever, Ashby, SmartRecruiters, TeamTailor, Recruitee, Workday. 300+ company verified registry.
+Seven ATS adapters shipped: Greenhouse, Lever, Ashby, SmartRecruiters, TeamTailor, Recruitee, Workday. 500+ company verified registry.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ All filters AND together. Deep dive on patterns and gotchas: [docs/filters.md](d
 - Greenhouse, Ashby, Lever, SmartRecruiters, Teamtailor, Recruitee, Workday adapters
 - Title, topic, location, and date filters
 - Salary extraction from JD text
-- Verified company registry (300+ companies)
+- Verified company registry (500+ companies)
 
 **Next**
 - Personio adapter (German / EU mid-market)

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>
+    var allowedHostnames = ['prpmdev.github.io'];
+    if (allowedHostnames.includes(location.hostname)) {
+      var s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://www.googletagmanager.com/gtag/js?id=G-342XCVT9FL';
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-342XCVT9FL');
+    }
+  </script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>jd-intel changelog: what your AI can search now</title>
+  <meta name="description" content="What changed in the jd-intel company registry, written in terms of what you can actually search. Coverage growth, platform migrations, and freshness dates.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="jd-intel changelog">
+  <meta property="og:description" content="What your AI can search now, release by release.">
+  <meta property="og:url" content="https://prpmdev.github.io/jd-intel/changelog.html">
+  <meta property="og:image" content="https://prpmdev.github.io/jd-intel/wordmark.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="jd-intel changelog">
+  <meta name="twitter:description" content="What your AI can search now, release by release.">
+  <meta name="twitter:image" content="https://prpmdev.github.io/jd-intel/wordmark.png">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <script>try{document.documentElement.dataset.theme=localStorage.getItem('jdintel-theme')||'light';}catch(e){}</script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="styles.css?v=20260627c">
+  <script defer src="theme.js?v=20260627c"></script>
+</head>
+<body>
+<div style="background:var(--bg); color:var(--fg); font-family:'Schibsted Grotesk',sans-serif; min-height:100vh; -webkit-font-smoothing:antialiased;">
+
+  <nav style="position:sticky; top:0; z-index:20; border-bottom:1px solid var(--line); background:color-mix(in srgb, var(--bg) 84%, transparent); backdrop-filter:saturate(180%) blur(10px); -webkit-backdrop-filter:saturate(180%) blur(10px);">
+    <div style="max-width:1120px; margin:0 auto; padding:0 40px; height:64px; display:flex; align-items:center; justify-content:space-between;">
+      <a href="index.html" style="font:600 17px/1 'JetBrains Mono',monospace; letter-spacing:-.02em; color:var(--fg); text-decoration:none;">jd-intel</a>
+      <div style="display:flex; align-items:center; gap:30px;">
+        <a href="index.html#demo" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Demo</a>
+        <a href="index.html#why" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Why</a>
+        <a href="index.html#how" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">How it works</a>
+        <a href="index.html#coverage" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Coverage</a>
+        <a href="guide.html" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Guide</a>
+        <a href="changelog.html" style="font:600 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg); text-decoration:none;">Changelog</a>
+        <button onclick="jdToggleTheme()" data-theme-icon aria-label="Toggle theme" style="width:34px; height:34px; border:1px solid var(--line-2); border-radius:999px; background:transparent; color:var(--fg-2); font-size:14px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center;">☾</button>
+        <a href="guide.html#setup" style="font:600 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--ink-fg); background:var(--ink); border-radius:9px; padding:10px 16px; text-decoration:none;">Install</a>
+      </div>
+    </div>
+  </nav>
+
+  <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(40px * var(--pad-scale));">
+    <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Changelog</div>
+    <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(40px,5vw,60px); line-height:1.03; letter-spacing:-.025em; margin:0 0 22px; max-width:17ch;">What your AI can search now.</h1>
+    <p style="font:400 19px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); max-width:620px; margin:0;">Every entry here is written in terms of coverage, not code. If a release does not change what you can find, it does not appear on this page. For setup and usage, see the <a href="guide.html" style="color:var(--fg); text-decoration:none; border-bottom:1px solid var(--line-2);">guide</a>.</p>
+  </header>
+
+  <div style="max-width:1120px; margin:0 auto; padding:0 40px calc(80px * var(--pad-scale)); display:grid; grid-template-columns:200px 1fr; gap:64px; align-items:start;">
+
+    <aside style="position:sticky; top:96px; display:flex; flex-direction:column; gap:7px;">
+      <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin-bottom:8px;">Releases</div>
+      <a href="#r-2026-08-23" style="font:500 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none; padding:3px 0;">23 Aug 2026</a>
+      <a href="#coverage-today" style="font:400 13.5px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-3); text-decoration:none; padding:2px 0 2px 14px;">Coverage today</a>
+      <a href="#how-verified" style="font:500 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none; padding:3px 0; margin-top:8px;">How this is verified</a>
+    </aside>
+
+    <main style="min-width:0; max-width:var(--measure);">
+
+      <!-- ============ RELEASE ============ -->
+      <section id="r-2026-08-23" style="scroll-margin-top:90px;">
+
+        <div style="display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; margin-bottom:14px;">
+          <span style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3);">23 August 2026</span>
+          <span style="font:600 11px/1 'JetBrains Mono',monospace; color:var(--ink-fg); background:var(--ink); border-radius:999px; padding:5px 9px;">Latest</span>
+        </div>
+
+        <h2 style="font-family:var(--display-font); font-weight:500; font-size:34px; line-height:1.1; letter-spacing:-.02em; margin:0 0 14px;">47% more companies to search</h2>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 32px;">The registry went from 355 to 522 companies. Five verification runs landed together, so this release is larger than a typical one. Healthcare, energy and gaming saw the biggest jumps, and European coverage roughly doubled.</p>
+
+        <!-- headline stat -->
+        <div style="border:1px solid var(--line-2); border-radius:15px; padding:30px 32px; background:var(--surface); box-shadow:var(--shadow); margin-bottom:32px; display:flex; gap:44px; flex-wrap:wrap;">
+          <div>
+            <div style="font-family:var(--display-font); font-weight:500; font-size:44px; line-height:1; letter-spacing:-.03em; margin-bottom:8px;">522</div>
+            <div style="font:400 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">companies you can search</div>
+          </div>
+          <div>
+            <div style="font-family:var(--display-font); font-weight:500; font-size:44px; line-height:1; letter-spacing:-.03em; margin-bottom:8px;">+47%</div>
+            <div style="font:400 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">since the last release</div>
+          </div>
+          <div>
+            <div style="font-family:var(--display-font); font-weight:500; font-size:44px; line-height:1; letter-spacing:-.03em; margin-bottom:8px;">7</div>
+            <div style="font:400 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">hiring platforms covered</div>
+          </div>
+        </div>
+
+        <!-- by field -->
+        <h3 style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em;">Where the coverage grew</h3>
+        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Percentages are against the size of each field before this release.</p>
+
+        <div style="border:1px solid var(--line); border-radius:15px; background:var(--surface); overflow:hidden; margin-bottom:32px;">
+          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
+            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Energy, climate and industrial</span>
+            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+200%</span>
+          </div>
+          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
+            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Healthcare and life sciences</span>
+            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+173%</span>
+          </div>
+          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
+            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Gaming and entertainment</span>
+            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+105%</span>
+          </div>
+          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
+            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Retail, consumer and ecommerce</span>
+            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+57%</span>
+          </div>
+          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
+            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Finance and payments</span>
+            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+22%</span>
+          </div>
+          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; align-items:center;">
+            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">AI and developer tools</span>
+            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+18%</span>
+          </div>
+        </div>
+
+        <!-- regions -->
+        <h3 style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em;">More of Europe</h3>
+        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Sourcing this cycle targeted Dutch, German, Belgian and Nordic employers, which had been thin. The two platforms most used by European companies grew the fastest of any we cover.</p>
+
+        <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:16px; margin-bottom:32px;">
+          <div style="border:1px solid var(--line); border-radius:13px; padding:20px 22px; background:var(--surface);">
+            <div style="font:600 15px/1 'JetBrains Mono',monospace; margin-bottom:10px;">+129%</div>
+            <p style="font:400 14.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Recruitee, used mostly by companies in the Netherlands, Germany and Belgium.</p>
+          </div>
+          <div style="border:1px solid var(--line); border-radius:13px; padding:20px 22px; background:var(--surface);">
+            <div style="font:600 15px/1 'JetBrains Mono',monospace; margin-bottom:10px;">+42%</div>
+            <p style="font:400 14.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">TeamTailor, used mostly by companies across the Nordics.</p>
+          </div>
+          <div style="border:1px solid var(--line); border-radius:13px; padding:20px 22px; background:var(--surface);">
+            <div style="font:600 15px/1 'JetBrains Mono',monospace; margin-bottom:10px;">+128%</div>
+            <p style="font:400 14.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">SmartRecruiters, which brought in more large multinational employers.</p>
+          </div>
+        </div>
+
+        <!-- accuracy -->
+        <h3 style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em;">Five companies moved, and still work</h3>
+        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Companies change hiring platform quietly, and tools that hard-code the old one go silently empty. Five were caught switching this cycle and re-pointed, so searches for them keep returning roles instead of nothing.</p>
+
+        <div style="border:1px solid var(--line); border-radius:15px; padding:22px 26px; background:var(--surface-2); margin-bottom:32px;">
+          <p style="font:400 14.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage and Planhat now resolve through Ashby. Sendcloud now resolves through TeamTailor. Nothing changes on your side: the company name works the same way it did before.</p>
+        </div>
+
+        <!-- coverage today -->
+        <h3 id="coverage-today" style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em; scroll-margin-top:90px;">Coverage today</h3>
+        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 36px;">522 companies across Greenhouse, Lever, Ashby, SmartRecruiters, TeamTailor, Recruitee and Workday. Unknown companies still work: jd-intel falls back to probing every platform, so the registry is a speed-up rather than a limit on what you can search.</p>
+
+      </section>
+
+      <!-- ============ METHOD ============ -->
+      <section id="how-verified" style="scroll-margin-top:90px; border-top:1px solid var(--line); padding-top:40px;">
+        <h2 style="font-family:var(--display-font); font-weight:500; font-size:28px; line-height:1.1; letter-spacing:-.02em; margin:0 0 14px;">How this is verified</h2>
+        <p style="font:400 16px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Every company on this page was checked against the live hiring platform and returned real, open roles at the time it was added. Nothing is added from a list or from memory. The whole registry is re-checked on each cycle, which is how platform moves get caught.</p>
+        <p style="font:400 16px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Coverage is accurate as of the date on each release, not permanently. Companies pause hiring and boards go quiet, so a small share of entries return nothing on any given day. The check that produces these numbers is in the repository and you can run it yourself:</p>
+        <pre style="margin:0 0 20px; font:500 13.5px/1.5 'JetBrains Mono',monospace; color:var(--fg); background:var(--surface-2); border:1px solid var(--line); border-radius:10px; padding:14px 16px; overflow-x:auto;">npm run verify:registry</pre>
+        <p style="font:400 15px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-3); margin:0;">Each expansion is staged as a pull request with its own verification table, so the evidence behind every release is public in the <a href="https://github.com/prPMDev/jd-intel/pulls?q=is%3Apr+is%3Aclosed" style="color:var(--fg-2); text-decoration:none; border-bottom:1px solid var(--line-2);">pull request history</a>.</p>
+      </section>
+
+    </main>
+  </div>
+
+  <footer style="border-top:1px solid var(--line); padding:46px 0 56px; background:var(--surface-2);">
+    <div style="max-width:1120px; margin:0 auto; padding:0 40px; display:flex; flex-wrap:wrap; gap:24px; align-items:flex-start; justify-content:space-between;">
+      <div style="max-width:460px;">
+        <div style="font:600 16px/1 'JetBrains Mono',monospace; letter-spacing:-.02em; color:var(--fg); margin-bottom:14px;">jd-intel</div>
+        <p style="font:400 14.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Built by Prashant R, a PM who builds. Trying out and shipping what really matters below the AI hype.</p>
+      </div>
+      <div style="display:flex; gap:40px; flex-wrap:wrap;">
+        <div style="display:flex; flex-direction:column; gap:10px;">
+          <span style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.08em; text-transform:uppercase; color:var(--fg-3); margin-bottom:2px;">Project</span>
+          <a href="index.html" style="font:500 14px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Home</a>
+          <a href="guide.html" style="font:500 14px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Guide</a>
+          <a href="https://github.com/prPMDev/jd-intel" style="font:500 14px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">GitHub</a>
+          <a href="https://www.npmjs.com/package/jd-intel-mcp" style="font:500 14px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">npm</a>
+        </div>
+        <div style="display:flex; flex-direction:column; gap:10px;">
+          <span style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.08em; text-transform:uppercase; color:var(--fg-3); margin-bottom:2px;">Maker</span>
+          <a href="https://prashantrana.xyz" style="font:500 14px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Portfolio</a>
+          <a href="https://www.linkedin.com/in/prashant-rana/" style="font:500 14px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">LinkedIn</a>
+        </div>
+      </div>
+    </div>
+    <div style="max-width:1120px; margin:34px auto 0; padding:0 40px; display:flex; justify-content:space-between; flex-wrap:wrap; gap:10px;">
+      <span style="font:400 13px/1 'JetBrains Mono',monospace; color:var(--fg-3);">© Prashant R</span>
+      <a href="https://github.com/prPMDev/jd-intel/blob/master/LICENSE" style="font:400 13px/1 'JetBrains Mono',monospace; color:var(--fg-3); text-decoration:none; border-bottom:1px solid var(--line-2);">MIT licensed</a>
+    </div>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -54,15 +54,15 @@
   </nav>
 
   <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
-    <div style="max-width:var(--measure); margin:0 auto;">
+    <div style="margin:0 auto;">
       <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0;">Changelog</h1>
     </div>
   </header>
 
   <main style="max-width:1120px; margin:0 auto; padding:0 40px calc(64px * var(--pad-scale));">
-    <div style="max-width:var(--measure); margin:0 auto;">
+    <div style="margin:0 auto;">
 
-      <!-- Newest release first. Copy this article block for each new one. -->
+      <!-- Newest release first. Copy an article block for each new release. -->
       <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
         <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-08-23</h2>
 
@@ -103,17 +103,32 @@
       </article>
 
       <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-06-27</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">A setup and troubleshooting guide, covering every supported client.</li>
+        </ul>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Changed</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Redesigned the site, including a dark mode that follows your system setting.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
         <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-06-26</h2>
 
         <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
         <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
-          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">One-click install. Download a bundle for Claude Desktop instead of editing a config file by hand.</li>
-          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Listed in the MCP Registry.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">One-click install for Claude Desktop. Download a bundle instead of editing a config file by hand.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Listed in the MCP Registry, so clients that read it can find jd-intel directly.</li>
         </ul>
 
         <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Changed</div>
         <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
           <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Errors are typed, so your AI can tell a wrong company name from a platform being down.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">The registry is fetched fresh at runtime, so new companies reach you without an upgrade.</li>
         </ul>
       </article>
 
@@ -131,7 +146,64 @@
 
         <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
         <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
-          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Workday support, the seventh platform. Workday boards can be reached directly by tenant.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Workday boards can be reached by tenant, so you can query one that is not in the registry yet.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-05-15</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Four hiring platforms: SmartRecruiters, TeamTailor, Recruitee and Workday. Coverage goes from three platforms to seven.</li>
+        </ul>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Fixed</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">TeamTailor boards on regional subdomains now resolve.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Two jobs with the same title at different locations no longer collapse into one.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-05-01</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">This site.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-04-24</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Works inside your AI assistant. Claude Desktop, Claude Code, Cursor, Windsurf and VS Code can all call jd-intel directly.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">One-command setup that writes the client config for you.</li>
+        </ul>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Changed</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Renamed from ats-index to jd-intel.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-04-17</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Filter by role title, description, location or posting date, so you ask for what you want instead of reading everything.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-04-03</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">First release. A library and command line tool covering Greenhouse, Ashby and Lever, returning every board in one shape.</li>
         </ul>
       </article>
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -72,7 +72,7 @@
 
         <h2 style="font-family:var(--display-font); font-weight:500; font-size:27px; line-height:1.15; letter-spacing:-.02em; margin:0 0 14px;">47% more companies. 355 to 522.</h2>
 
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Energy and industrial grew most, up 200%. Healthcare and life sciences up 173%, gaming up 105%. European coverage about doubled, mostly Dutch, German and Nordic employers. Five weeks of runs landed at once.</p>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Energy and industrial grew most, up 200%. Healthcare and life sciences up 173%, gaming up 105%. European coverage about doubled, mostly Dutch, German and Nordic employers.</p>
 
         <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage, Planhat and Sendcloud all switched hiring platform. They point at the new one now, so they still turn up when you search.</p>
       </article>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -55,35 +55,29 @@
 
   <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
     <div style="max-width:var(--measure); margin:0 auto;">
-      <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Changelog</div>
-      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0; max-width:17ch;">What your AI can search now.</h1>
+      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0;">Changelog</h1>
     </div>
   </header>
 
   <main style="max-width:1120px; margin:0 auto; padding:0 40px calc(64px * var(--pad-scale));">
     <div style="max-width:var(--measure); margin:0 auto;">
 
-      <!-- ============ RELEASE ============ -->
-      <article style="border-top:1px solid var(--line); padding:28px 0 34px;">
-        <div style="display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; margin-bottom:12px;">
-          <span style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3);">23 Aug 2026</span>
-          <span style="font:600 10.5px/1 'JetBrains Mono',monospace; color:var(--ink-fg); background:var(--ink); border-radius:999px; padding:4px 8px;">Latest</span>
-        </div>
+      <!-- Newest release first. Copy this article block for each new one. -->
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-08-23</h2>
 
-        <h2 style="font-family:var(--display-font); font-weight:500; font-size:27px; line-height:1.15; letter-spacing:-.02em; margin:0 0 14px;">47% more companies. 355 to 522.</h2>
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">167 companies. The registry is now 522, up 47%.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Energy and industrial +200%, healthcare and life sciences +173%, gaming and entertainment +105%.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">European coverage roughly doubled, mostly Dutch, German and Nordic employers.</li>
+        </ul>
 
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Energy and industrial grew most, up 200%. Healthcare and life sciences up 173%, gaming up 105%. European coverage about doubled, mostly Dutch, German and Nordic employers.</p>
-
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage, Planhat and Sendcloud all switched hiring platform. They point at the new one now, so they still turn up when you search.</p>
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Changed</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">WHOOP, Nubank, CareMessage, Planhat and Sendcloud switched hiring platform. All five now resolve to the new one.</li>
+        </ul>
       </article>
-
-      <!-- Future releases append above this line, newest first. -->
-
-      <!-- ============ METHOD ============ -->
-      <section style="border-top:1px solid var(--line); padding-top:28px;">
-        <h2 style="font:600 17px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 12px; letter-spacing:-.01em;">How this is verified</h2>
-        <p style="font:400 15.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">A company only gets added if its hiring board is live and returning open roles. Every cycle re-checks the whole registry, which is how the five moves above turned up. Boards also go quiet, so some entries come back empty on a given day. Run <span style="font-family:'JetBrains Mono',monospace; font-size:.92em; color:var(--fg);">npm run verify:registry</span> to see where things stand, or open the <a href="https://github.com/prPMDev/jd-intel/pulls?q=is%3Apr+is%3Aclosed" style="color:var(--fg-2); text-decoration:none; border-bottom:1px solid var(--line-2);">pull requests</a>.</p>
-      </section>
 
     </div>
   </main>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -54,14 +54,14 @@
   </nav>
 
   <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
-    <div style="max-width:var(--measure);">
+    <div style="max-width:var(--measure); margin:0 auto;">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Changelog</div>
       <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0; max-width:17ch;">What your AI can search now.</h1>
     </div>
   </header>
 
   <main style="max-width:1120px; margin:0 auto; padding:0 40px calc(64px * var(--pad-scale));">
-    <div style="max-width:var(--measure);">
+    <div style="max-width:var(--measure); margin:0 auto;">
 
       <!-- ============ RELEASE ============ -->
       <article style="border-top:1px solid var(--line); padding:28px 0 34px;">
@@ -72,7 +72,7 @@
 
         <h2 style="font-family:var(--display-font); font-weight:500; font-size:27px; line-height:1.15; letter-spacing:-.02em; margin:0 0 14px;">47% more companies. 355 to 522.</h2>
 
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Energy and industrial grew most, up 200%. Healthcare and life sciences up 173%, gaming up 105%. European coverage about doubled, mostly Dutch, German and Nordic employers. Five weeks of runs landed at once, so this one is big.</p>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Energy and industrial grew most, up 200%. Healthcare and life sciences up 173%, gaming up 105%. European coverage about doubled, mostly Dutch, German and Nordic employers. Five weeks of runs landed at once.</p>
 
         <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage, Planhat and Sendcloud all switched hiring platform. They point at the new one now, so they still turn up when you search.</p>
       </article>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -38,7 +38,7 @@
 <div style="background:var(--bg); color:var(--fg); font-family:'Schibsted Grotesk',sans-serif; min-height:100vh; -webkit-font-smoothing:antialiased;">
 
   <nav style="position:sticky; top:0; z-index:20; border-bottom:1px solid var(--line); background:color-mix(in srgb, var(--bg) 84%, transparent); backdrop-filter:saturate(180%) blur(10px); -webkit-backdrop-filter:saturate(180%) blur(10px);">
-    <div style="max-width:1120px; margin:0 auto; padding:0 40px; height:64px; display:flex; align-items:center; justify-content:space-between;">
+    <div style="max-width:820px; margin:0 auto; padding:0 40px; height:64px; display:flex; align-items:center; justify-content:space-between;">
       <a href="index.html" style="font:600 17px/1 'JetBrains Mono',monospace; letter-spacing:-.02em; color:var(--fg); text-decoration:none;">jd-intel</a>
       <div style="display:flex; align-items:center; gap:30px;">
         <a href="index.html#demo" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Demo</a>
@@ -53,13 +53,13 @@
     </div>
   </nav>
 
-  <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
+  <header style="max-width:820px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
     <div style="margin:0 auto;">
       <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0;">Changelog</h1>
     </div>
   </header>
 
-  <main style="max-width:1120px; margin:0 auto; padding:0 40px calc(64px * var(--pad-scale));">
+  <main style="max-width:820px; margin:0 auto; padding:0 40px calc(64px * var(--pad-scale));">
     <div style="margin:0 auto;">
 
       <!-- Newest release first. Copy an article block for each new release. -->
@@ -211,7 +211,7 @@
   </main>
 
   <footer style="border-top:1px solid var(--line); padding:46px 0 56px; background:var(--surface-2);">
-    <div style="max-width:1120px; margin:0 auto; padding:0 40px; display:flex; flex-wrap:wrap; gap:24px; align-items:flex-start; justify-content:space-between;">
+    <div style="max-width:820px; margin:0 auto; padding:0 40px; display:flex; flex-wrap:wrap; gap:24px; align-items:flex-start; justify-content:space-between;">
       <div style="max-width:460px;">
         <div style="font:600 16px/1 'JetBrains Mono',monospace; letter-spacing:-.02em; color:var(--fg); margin-bottom:14px;">jd-intel</div>
         <p style="font:400 14.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Built by Prashant R, a PM who builds. Trying out and shipping what really matters below the AI hype.</p>
@@ -231,7 +231,7 @@
         </div>
       </div>
     </div>
-    <div style="max-width:1120px; margin:34px auto 0; padding:0 40px; display:flex; justify-content:space-between; flex-wrap:wrap; gap:10px;">
+    <div style="max-width:820px; margin:34px auto 0; padding:0 40px; display:flex; justify-content:space-between; flex-wrap:wrap; gap:10px;">
       <span style="font:400 13px/1 'JetBrains Mono',monospace; color:var(--fg-3);">© Prashant R</span>
       <a href="https://github.com/prPMDev/jd-intel/blob/master/LICENSE" style="font:400 13px/1 'JetBrains Mono',monospace; color:var(--fg-3); text-decoration:none; border-bottom:1px solid var(--line-2);">MIT licensed</a>
     </div>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -56,8 +56,7 @@
   <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
     <div style="max-width:var(--measure);">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Changelog</div>
-      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0 0 20px; max-width:17ch;">What your AI can search now.</h1>
-      <p style="font:400 18px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Coverage changes, in plain terms. Percentages are measured against the registry as it stood before each release. Setup lives in the <a href="guide.html" style="color:var(--fg); text-decoration:none; border-bottom:1px solid var(--line-2);">guide</a>.</p>
+      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0; max-width:17ch;">What your AI can search now.</h1>
     </div>
   </header>
 
@@ -73,9 +72,9 @@
 
         <h2 style="font-family:var(--display-font); font-weight:500; font-size:27px; line-height:1.15; letter-spacing:-.02em; margin:0 0 14px;">47% more companies. 355 to 522.</h2>
 
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Biggest gains in energy and industrial (+200%), healthcare and life sciences (+173%), and gaming and entertainment (+105%). European coverage roughly doubled, led by Dutch, German and Nordic employers. Five weeks of verification runs shipped together, so this one is unusually large.</p>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Energy and industrial grew most, up 200%. Healthcare and life sciences up 173%, gaming up 105%. European coverage about doubled, mostly Dutch, German and Nordic employers. Five weeks of runs landed at once, so this one is big.</p>
 
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage, Planhat and Sendcloud each moved to a different hiring platform and were re-pointed, so searches for them keep returning roles instead of nothing.</p>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage, Planhat and Sendcloud all switched hiring platform. They point at the new one now, so they still turn up when you search.</p>
       </article>
 
       <!-- Future releases append above this line, newest first. -->
@@ -83,8 +82,7 @@
       <!-- ============ METHOD ============ -->
       <section style="border-top:1px solid var(--line); padding-top:28px;">
         <h2 style="font:600 17px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 12px; letter-spacing:-.01em;">How this is verified</h2>
-        <p style="font:400 15.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 12px;">Every company is checked against the live hiring platform and has to return real open roles before it is added. Nothing comes from a list or from memory. The whole registry is re-checked each cycle, which is how platform moves get caught.</p>
-        <p style="font:400 15.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Coverage is accurate as of the date on each release, not permanently. Companies pause hiring and boards go quiet, so a small share return nothing on any given day. Run the same check yourself with <span style="font-family:'JetBrains Mono',monospace; font-size:.92em; color:var(--fg);">npm run verify:registry</span>, or read the evidence behind each release in the <a href="https://github.com/prPMDev/jd-intel/pulls?q=is%3Apr+is%3Aclosed" style="color:var(--fg-2); text-decoration:none; border-bottom:1px solid var(--line-2);">pull request history</a>.</p>
+        <p style="font:400 15.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">A company only gets added if its hiring board is live and returning open roles. Every cycle re-checks the whole registry, which is how the five moves above turned up. Boards also go quiet, so some entries come back empty on a given day. Run <span style="font-family:'JetBrains Mono',monospace; font-size:.92em; color:var(--fg);">npm run verify:registry</span> to see where things stand, or open the <a href="https://github.com/prPMDev/jd-intel/pulls?q=is%3Apr+is%3Aclosed" style="color:var(--fg-2); text-decoration:none; border-bottom:1px solid var(--line-2);">pull requests</a>.</p>
       </section>
 
     </div>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -79,6 +79,62 @@
         </ul>
       </article>
 
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-07-12</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">24 companies across six platforms. The registry is now 355.</li>
+        </ul>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Changed</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Plaid moved from Lever to Ashby.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-07-09</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">15 companies across three platforms. The registry is now 331.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-06-26</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0 0 22px; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">One-click install. Download a bundle for Claude Desktop instead of editing a config file by hand.</li>
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Listed in the MCP Registry.</li>
+        </ul>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Changed</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Errors are typed, so your AI can tell a wrong company name from a platform being down.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-06-17</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">152 companies across all seven platforms, taking the registry from 163 to 315.</li>
+        </ul>
+      </article>
+
+      <article style="border-top:1px solid var(--line); padding:26px 0 30px;">
+        <h2 style="font:600 15px/1 'JetBrains Mono',monospace; letter-spacing:-.01em; color:var(--fg); margin:0 0 22px;">2026-05-19</h2>
+
+        <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin:0 0 10px;">Added</div>
+        <ul style="margin:0; padding:0 0 0 20px; display:flex; flex-direction:column; gap:7px;">
+          <li style="font:400 16px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">Workday support, the seventh platform. Workday boards can be reached directly by tenant.</li>
+        </ul>
+      </article>
+
     </div>
   </main>
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -17,7 +17,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>jd-intel changelog: what your AI can search now</title>
-  <meta name="description" content="What changed in the jd-intel company registry, written in terms of what you can actually search. Coverage growth, platform migrations, and freshness dates.">
+  <meta name="description" content="What changed in the jd-intel company registry, written in terms of what you can actually search.">
   <meta property="og:type" content="website">
   <meta property="og:title" content="jd-intel changelog">
   <meta property="og:description" content="What your AI can search now, release by release.">
@@ -53,125 +53,42 @@
     </div>
   </nav>
 
-  <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(40px * var(--pad-scale));">
-    <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Changelog</div>
-    <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(40px,5vw,60px); line-height:1.03; letter-spacing:-.025em; margin:0 0 22px; max-width:17ch;">What your AI can search now.</h1>
-    <p style="font:400 19px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); max-width:620px; margin:0;">Every entry here is written in terms of coverage, not code. If a release does not change what you can find, it does not appear on this page. For setup and usage, see the <a href="guide.html" style="color:var(--fg); text-decoration:none; border-bottom:1px solid var(--line-2);">guide</a>.</p>
+  <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(34px * var(--pad-scale));">
+    <div style="max-width:var(--measure);">
+      <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Changelog</div>
+      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(38px,5vw,54px); line-height:1.05; letter-spacing:-.025em; margin:0 0 20px; max-width:17ch;">What your AI can search now.</h1>
+      <p style="font:400 18px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Coverage changes, in plain terms. Percentages are measured against the registry as it stood before each release. Setup lives in the <a href="guide.html" style="color:var(--fg); text-decoration:none; border-bottom:1px solid var(--line-2);">guide</a>.</p>
+    </div>
   </header>
 
-  <div style="max-width:1120px; margin:0 auto; padding:0 40px calc(80px * var(--pad-scale)); display:grid; grid-template-columns:200px 1fr; gap:64px; align-items:start;">
-
-    <aside style="position:sticky; top:96px; display:flex; flex-direction:column; gap:7px;">
-      <div style="font:500 11.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3); margin-bottom:8px;">Releases</div>
-      <a href="#r-2026-08-23" style="font:500 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none; padding:3px 0;">23 Aug 2026</a>
-      <a href="#coverage-today" style="font:400 13.5px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-3); text-decoration:none; padding:2px 0 2px 14px;">Coverage today</a>
-      <a href="#how-verified" style="font:500 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none; padding:3px 0; margin-top:8px;">How this is verified</a>
-    </aside>
-
-    <main style="min-width:0; max-width:var(--measure);">
+  <main style="max-width:1120px; margin:0 auto; padding:0 40px calc(64px * var(--pad-scale));">
+    <div style="max-width:var(--measure);">
 
       <!-- ============ RELEASE ============ -->
-      <section id="r-2026-08-23" style="scroll-margin-top:90px;">
-
-        <div style="display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; margin-bottom:14px;">
-          <span style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3);">23 August 2026</span>
-          <span style="font:600 11px/1 'JetBrains Mono',monospace; color:var(--ink-fg); background:var(--ink); border-radius:999px; padding:5px 9px;">Latest</span>
+      <article style="border-top:1px solid var(--line); padding:28px 0 34px;">
+        <div style="display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; margin-bottom:12px;">
+          <span style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--fg-3);">23 Aug 2026</span>
+          <span style="font:600 10.5px/1 'JetBrains Mono',monospace; color:var(--ink-fg); background:var(--ink); border-radius:999px; padding:4px 8px;">Latest</span>
         </div>
 
-        <h2 style="font-family:var(--display-font); font-weight:500; font-size:34px; line-height:1.1; letter-spacing:-.02em; margin:0 0 14px;">47% more companies to search</h2>
-        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 32px;">The registry went from 355 to 522 companies. Five verification runs landed together, so this release is larger than a typical one. Healthcare, energy and gaming saw the biggest jumps, and European coverage roughly doubled.</p>
+        <h2 style="font-family:var(--display-font); font-weight:500; font-size:27px; line-height:1.15; letter-spacing:-.02em; margin:0 0 14px;">47% more companies. 355 to 522.</h2>
 
-        <!-- headline stat -->
-        <div style="border:1px solid var(--line-2); border-radius:15px; padding:30px 32px; background:var(--surface); box-shadow:var(--shadow); margin-bottom:32px; display:flex; gap:44px; flex-wrap:wrap;">
-          <div>
-            <div style="font-family:var(--display-font); font-weight:500; font-size:44px; line-height:1; letter-spacing:-.03em; margin-bottom:8px;">522</div>
-            <div style="font:400 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">companies you can search</div>
-          </div>
-          <div>
-            <div style="font-family:var(--display-font); font-weight:500; font-size:44px; line-height:1; letter-spacing:-.03em; margin-bottom:8px;">+47%</div>
-            <div style="font:400 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">since the last release</div>
-          </div>
-          <div>
-            <div style="font-family:var(--display-font); font-weight:500; font-size:44px; line-height:1; letter-spacing:-.03em; margin-bottom:8px;">7</div>
-            <div style="font:400 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2);">hiring platforms covered</div>
-          </div>
-        </div>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Biggest gains in energy and industrial (+200%), healthcare and life sciences (+173%), and gaming and entertainment (+105%). European coverage roughly doubled, led by Dutch, German and Nordic employers. Five weeks of verification runs shipped together, so this one is unusually large.</p>
 
-        <!-- by field -->
-        <h3 style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em;">Where the coverage grew</h3>
-        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Percentages are against the size of each field before this release.</p>
+        <p style="font:400 16.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage, Planhat and Sendcloud each moved to a different hiring platform and were re-pointed, so searches for them keep returning roles instead of nothing.</p>
+      </article>
 
-        <div style="border:1px solid var(--line); border-radius:15px; background:var(--surface); overflow:hidden; margin-bottom:32px;">
-          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
-            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Energy, climate and industrial</span>
-            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+200%</span>
-          </div>
-          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
-            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Healthcare and life sciences</span>
-            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+173%</span>
-          </div>
-          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
-            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Gaming and entertainment</span>
-            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+105%</span>
-          </div>
-          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
-            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Retail, consumer and ecommerce</span>
-            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+57%</span>
-          </div>
-          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; border-bottom:1px solid var(--line); align-items:center;">
-            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">Finance and payments</span>
-            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+22%</span>
-          </div>
-          <div style="display:grid; grid-template-columns:1fr auto; gap:16px; padding:16px 22px; align-items:center;">
-            <span style="font:500 15.5px/1.4 'Schibsted Grotesk',sans-serif;">AI and developer tools</span>
-            <span style="font:600 15px/1 'JetBrains Mono',monospace; color:var(--fg);">+18%</span>
-          </div>
-        </div>
-
-        <!-- regions -->
-        <h3 style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em;">More of Europe</h3>
-        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Sourcing this cycle targeted Dutch, German, Belgian and Nordic employers, which had been thin. The two platforms most used by European companies grew the fastest of any we cover.</p>
-
-        <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:16px; margin-bottom:32px;">
-          <div style="border:1px solid var(--line); border-radius:13px; padding:20px 22px; background:var(--surface);">
-            <div style="font:600 15px/1 'JetBrains Mono',monospace; margin-bottom:10px;">+129%</div>
-            <p style="font:400 14.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Recruitee, used mostly by companies in the Netherlands, Germany and Belgium.</p>
-          </div>
-          <div style="border:1px solid var(--line); border-radius:13px; padding:20px 22px; background:var(--surface);">
-            <div style="font:600 15px/1 'JetBrains Mono',monospace; margin-bottom:10px;">+42%</div>
-            <p style="font:400 14.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">TeamTailor, used mostly by companies across the Nordics.</p>
-          </div>
-          <div style="border:1px solid var(--line); border-radius:13px; padding:20px 22px; background:var(--surface);">
-            <div style="font:600 15px/1 'JetBrains Mono',monospace; margin-bottom:10px;">+128%</div>
-            <p style="font:400 14.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">SmartRecruiters, which brought in more large multinational employers.</p>
-          </div>
-        </div>
-
-        <!-- accuracy -->
-        <h3 style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em;">Five companies moved, and still work</h3>
-        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Companies change hiring platform quietly, and tools that hard-code the old one go silently empty. Five were caught switching this cycle and re-pointed, so searches for them keep returning roles instead of nothing.</p>
-
-        <div style="border:1px solid var(--line); border-radius:15px; padding:22px 26px; background:var(--surface-2); margin-bottom:32px;">
-          <p style="font:400 14.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">WHOOP, Nubank, CareMessage and Planhat now resolve through Ashby. Sendcloud now resolves through TeamTailor. Nothing changes on your side: the company name works the same way it did before.</p>
-        </div>
-
-        <!-- coverage today -->
-        <h3 id="coverage-today" style="font:600 19px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 8px; letter-spacing:-.01em; scroll-margin-top:90px;">Coverage today</h3>
-        <p style="font:400 15.5px/1.55 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 36px;">522 companies across Greenhouse, Lever, Ashby, SmartRecruiters, TeamTailor, Recruitee and Workday. Unknown companies still work: jd-intel falls back to probing every platform, so the registry is a speed-up rather than a limit on what you can search.</p>
-
-      </section>
+      <!-- Future releases append above this line, newest first. -->
 
       <!-- ============ METHOD ============ -->
-      <section id="how-verified" style="scroll-margin-top:90px; border-top:1px solid var(--line); padding-top:40px;">
-        <h2 style="font-family:var(--display-font); font-weight:500; font-size:28px; line-height:1.1; letter-spacing:-.02em; margin:0 0 14px;">How this is verified</h2>
-        <p style="font:400 16px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Every company on this page was checked against the live hiring platform and returned real, open roles at the time it was added. Nothing is added from a list or from memory. The whole registry is re-checked on each cycle, which is how platform moves get caught.</p>
-        <p style="font:400 16px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 20px;">Coverage is accurate as of the date on each release, not permanently. Companies pause hiring and boards go quiet, so a small share of entries return nothing on any given day. The check that produces these numbers is in the repository and you can run it yourself:</p>
-        <pre style="margin:0 0 20px; font:500 13.5px/1.5 'JetBrains Mono',monospace; color:var(--fg); background:var(--surface-2); border:1px solid var(--line); border-radius:10px; padding:14px 16px; overflow-x:auto;">npm run verify:registry</pre>
-        <p style="font:400 15px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-3); margin:0;">Each expansion is staged as a pull request with its own verification table, so the evidence behind every release is public in the <a href="https://github.com/prPMDev/jd-intel/pulls?q=is%3Apr+is%3Aclosed" style="color:var(--fg-2); text-decoration:none; border-bottom:1px solid var(--line-2);">pull request history</a>.</p>
+      <section style="border-top:1px solid var(--line); padding-top:28px;">
+        <h2 style="font:600 17px/1.3 'Schibsted Grotesk',sans-serif; margin:0 0 12px; letter-spacing:-.01em;">How this is verified</h2>
+        <p style="font:400 15.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 12px;">Every company is checked against the live hiring platform and has to return real open roles before it is added. Nothing comes from a list or from memory. The whole registry is re-checked each cycle, which is how platform moves get caught.</p>
+        <p style="font:400 15.5px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 14px;">Coverage is accurate as of the date on each release, not permanently. Companies pause hiring and boards go quiet, so a small share return nothing on any given day. Run the same check yourself with <span style="font-family:'JetBrains Mono',monospace; font-size:.92em; color:var(--fg);">npm run verify:registry</span>, or read the evidence behind each release in the <a href="https://github.com/prPMDev/jd-intel/pulls?q=is%3Apr+is%3Aclosed" style="color:var(--fg-2); text-decoration:none; border-bottom:1px solid var(--line-2);">pull request history</a>.</p>
       </section>
 
-    </main>
-  </div>
+    </div>
+  </main>
 
   <footer style="border-top:1px solid var(--line); padding:46px 0 56px; background:var(--surface-2);">
     <div style="max-width:1120px; margin:0 auto; padding:0 40px; display:flex; flex-wrap:wrap; gap:24px; align-items:flex-start; justify-content:space-between;">

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -55,8 +55,8 @@
 
   <header style="max-width:1120px; margin:0 auto; padding:calc(72px * var(--pad-scale)) 40px calc(40px * var(--pad-scale));">
     <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:24px;">Documentation</div>
-    <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(40px,5vw,60px); line-height:1.03; letter-spacing:-.025em; margin:0 0 22px; max-width:16ch;">Setup, usage, and troubleshooting.</h1>
-    <p style="font:400 19px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); max-width:600px; margin:0;">Install jd-intel in your AI client, learn what to ask, and fix the common snags. New here? Start on the <a href="index.html" style="color:var(--fg); text-decoration:none; border-bottom:1px solid var(--line-2);">home page</a>.</p>
+    <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(40px,5vw,60px); line-height:1.03; letter-spacing:-.025em; margin:0 0 22px;">Setup, usage, and troubleshooting.</h1>
+    <p style="font:400 19px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Install jd-intel in your AI client, learn what to ask, and fix the common snags. New here? Start on the <a href="index.html" style="color:var(--fg); text-decoration:none; border-bottom:1px solid var(--line-2);">home page</a>.</p>
   </header>
 
   <div style="max-width:1120px; margin:0 auto; padding:0 40px calc(80px * var(--pad-scale)); display:grid; grid-template-columns:200px 1fr; gap:64px; align-items:start;">
@@ -72,7 +72,7 @@
       <a href="#troubleshooting" style="font:500 14px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none; padding:3px 0; margin-top:8px;">Troubleshooting</a>
     </aside>
 
-    <main style="min-width:0; max-width:var(--measure);">
+    <main style="min-width:0;">
 
       <section id="setup" style="scroll-margin-top:90px;">
         <h2 style="font-family:var(--display-font); font-weight:500; font-size:34px; line-height:1.1; letter-spacing:-.02em; margin:0 0 14px;">Setup</h2>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -46,6 +46,7 @@
         <a href="index.html#how" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">How it works</a>
         <a href="index.html#coverage" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Coverage</a>
         <a href="guide.html" style="font:600 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg); text-decoration:none;">Guide</a>
+        <a href="changelog.html" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Changelog</a>
         <button onclick="jdToggleTheme()" data-theme-icon aria-label="Toggle theme" style="width:34px; height:34px; border:1px solid var(--line-2); border-radius:999px; background:transparent; color:var(--fg-2); font-size:14px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center;">☾</button>
         <a href="#setup" style="font:600 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--ink-fg); background:var(--ink); border-radius:9px; padding:10px 16px; text-decoration:none;">Install</a>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,10 +59,26 @@
   <main style="max-width:1120px; margin:0 auto; padding:0 40px;">
 
     <!-- ============ HERO ============ -->
-    <section style="padding:calc(96px * var(--pad-scale)) 0 calc(44px * var(--pad-scale)); display:grid; grid-template-columns:1fr; gap:0; max-width:880px;">
+    <section style="padding:calc(96px * var(--pad-scale)) 0 calc(44px * var(--pad-scale)); display:grid; grid-template-columns:1fr; gap:0;">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:30px;">Job search, handled by the AI you already use</div>
       <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(44px,6.1vw,70px); line-height:1.02; letter-spacing:-.025em; margin:0 0 28px; max-width:16ch;">Stop pasting job descriptions into your AI.</h1>
-      <p style="font:400 21px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); max-width:600px; margin:0 0 38px;">jd-intel gives your assistant a direct line to real, current job openings. You ask in plain language. It finds the roles that fit you and ranks them against your background. No copy and paste, no new tool to learn.</p>
+      <div style="display:flex; gap:64px; align-items:flex-start; justify-content:space-between; flex-wrap:wrap; margin:0 0 38px;">
+        <p style="font:400 21px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); flex:1 1 420px; max-width:600px; margin:0;">jd-intel gives your assistant a direct line to real, current job openings. You ask in plain language. It finds the roles that fit you and ranks them against your background. No copy and paste, no new tool to learn.</p>
+        <div style="flex:0 1 auto; display:flex; flex-direction:column; gap:18px; border-left:1px solid var(--line); padding-left:28px;">
+          <div>
+            <div style="font:600 22px/1 'JetBrains Mono',monospace; color:var(--fg); margin-bottom:6px;">522</div>
+            <div style="font:400 13.5px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-3);">verified companies</div>
+          </div>
+          <div>
+            <div style="font:600 22px/1 'JetBrains Mono',monospace; color:var(--fg); margin-bottom:6px;">7</div>
+            <div style="font:400 13.5px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-3);">hiring platforms</div>
+          </div>
+          <div>
+            <div style="font:600 22px/1 'JetBrains Mono',monospace; color:var(--fg); margin-bottom:6px;">MIT</div>
+            <div style="font:400 13.5px/1.4 'Schibsted Grotesk',sans-serif; color:var(--fg-3);">open source, runs locally</div>
+          </div>
+        </div>
+      </div>
       <div style="display:flex; gap:14px; align-items:center; flex-wrap:wrap;">
         <a href="#demo" style="font:600 16px/1 'Schibsted Grotesk',sans-serif; color:var(--ink-fg); background:var(--ink); border-radius:11px; padding:15px 24px; text-decoration:none;">See the demo</a>
         <a href="#install" style="font:600 16px/1 'Schibsted Grotesk',sans-serif; color:var(--fg); border:1px solid var(--line-2); border-radius:11px; padding:15px 24px; text-decoration:none;">Install in 2 minutes</a>
@@ -99,7 +115,7 @@
       </div>
 
       <div style="margin-top:30px; border:1px solid var(--line-2); border-radius:15px; padding:38px 40px; background:var(--surface-2);">
-        <p style="font-family:var(--display-font); font-weight:400; font-size:clamp(24px,2.7vw,32px); line-height:1.32; letter-spacing:-.01em; margin:0; max-width:34ch; color:var(--fg);">jd-intel takes the tax off. It hands current, real postings to the assistant that already knows your background, so <em style="font-style:italic;">your</em> context does the ranking. Not a board's algorithm. Not another tab to manage.</p>
+        <p style="font-family:var(--display-font); font-weight:400; font-size:clamp(24px,2.7vw,32px); line-height:1.32; letter-spacing:-.01em; margin:0; max-width:48ch; color:var(--fg);">jd-intel takes the tax off. It hands current, real postings to the assistant that already knows your background, so <em style="font-style:italic;">your</em> context does the ranking. Not a board's algorithm. Not another tab to manage.</p>
       </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@
         <a href="#how" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">How it works</a>
         <a href="#coverage" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Coverage</a>
         <a href="guide.html" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Guide</a>
+        <a href="changelog.html" style="font:500 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--fg-2); text-decoration:none;">Changelog</a>
         <button onclick="jdToggleTheme()" data-theme-icon aria-label="Toggle theme" style="width:34px; height:34px; border:1px solid var(--line-2); border-radius:999px; background:transparent; color:var(--fg-2); font-size:14px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center;">☾</button>
         <a href="#install" style="font:600 14.5px/1 'Schibsted Grotesk',sans-serif; color:var(--ink-fg); background:var(--ink); border-radius:9px; padding:10px 16px; text-decoration:none;">Install</a>
       </div>
@@ -175,7 +176,7 @@
       <div style="border:1px solid var(--line); border-radius:15px; padding:30px 32px; background:var(--surface);">
         <div style="display:flex; align-items:baseline; justify-content:space-between; flex-wrap:wrap; gap:12px; margin-bottom:22px;">
           <span style="font:600 16px/1 'Schibsted Grotesk',sans-serif; color:var(--fg);">Covered today</span>
-          <span style="font:500 13.5px/1 'JetBrains Mono',monospace; color:var(--fg-3);">300+ verified companies in the registry</span>
+          <span style="font:500 13.5px/1 'JetBrains Mono',monospace; color:var(--fg-3);">500+ verified companies in the registry</span>
         </div>
         <div style="display:flex; flex-wrap:wrap; gap:10px; margin-bottom:24px;">
           <span style="border:1px solid var(--line-2); border-radius:999px; padding:9px 15px; font:500 14px/1 'Schibsted Grotesk',sans-serif;">Greenhouse</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,9 +61,9 @@
     <!-- ============ HERO ============ -->
     <section style="padding:calc(96px * var(--pad-scale)) 0 calc(44px * var(--pad-scale)); display:grid; grid-template-columns:1fr; gap:0;">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:30px;">Job search, handled by the AI you already use</div>
-      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(44px,6.1vw,70px); line-height:1.02; letter-spacing:-.025em; margin:0 0 28px; max-width:16ch;">Stop pasting job descriptions into your AI.</h1>
+      <h1 style="font-family:var(--display-font); font-weight:500; font-size:clamp(44px,6.1vw,70px); line-height:1.02; letter-spacing:-.025em; margin:0 0 28px;">Stop pasting job descriptions into your AI.</h1>
       <div style="display:flex; gap:64px; align-items:flex-start; justify-content:space-between; flex-wrap:wrap; margin:0 0 38px;">
-        <p style="font:400 21px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); flex:1 1 420px; max-width:600px; margin:0;">jd-intel gives your assistant a direct line to real, current job openings. You ask in plain language. It finds the roles that fit you and ranks them against your background. No copy and paste, no new tool to learn.</p>
+        <p style="font:400 21px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); flex:1 1 420px; margin:0;">jd-intel gives your assistant a direct line to real, current job openings. You ask in plain language. It finds the roles that fit you and ranks them against your background. No copy and paste, no new tool to learn.</p>
         <div style="flex:0 1 auto; display:flex; flex-direction:column; gap:18px; border-left:1px solid var(--line); padding-left:28px;">
           <div>
             <div style="font:600 22px/1 'JetBrains Mono',monospace; color:var(--fg); margin-bottom:6px;">522</div>
@@ -88,7 +88,7 @@
     <!-- ============ WATCH A DEMO ============ -->
     <section id="demo" style="padding:calc(92px * var(--pad-scale)) 0; border-top:1px solid var(--line);">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:22px;">Watch a demo</div>
-      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 56px; max-width:18ch;">One question, then a conversation.</h2>
+      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 56px;">One question, then a conversation.</h2>
       <div style="border:1px solid var(--line); border-radius:16px; overflow:hidden; box-shadow:var(--shadow); background:#1e1c18;">
         <iframe src="jd-intel-loop.html?v=20260708" title="jd-intel demo: a simulated session, on a loop" loading="lazy" style="width:100%; aspect-ratio:1060/700; border:0; display:block;"></iframe>
       </div>
@@ -98,8 +98,8 @@
     <!-- ============ WHY ============ -->
     <section id="why" style="padding:calc(92px * var(--pad-scale)) 0; border-top:1px solid var(--line);">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:22px;">Why this exists</div>
-      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 14px; max-width:20ch;">Everyone says start with the job boards. Both ways of doing it cost you.</h2>
-      <p style="font:400 18px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); max-width:560px; margin:0 0 48px;">However you chase an edge in the search today, you pay a tax on your own leverage.</p>
+      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 14px;">Everyone says start with the job boards. Both ways of doing it cost you.</h2>
+      <p style="font:400 18px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 48px;">However you chase an edge in the search today, you pay a tax on your own leverage.</p>
 
       <div style="display:grid; grid-template-columns:1fr 1fr; gap:22px;">
         <div style="border:1px solid var(--line); border-radius:15px; padding:30px 30px 32px; background:var(--surface);">
@@ -115,14 +115,14 @@
       </div>
 
       <div style="margin-top:30px; border:1px solid var(--line-2); border-radius:15px; padding:38px 40px; background:var(--surface-2);">
-        <p style="font-family:var(--display-font); font-weight:400; font-size:clamp(24px,2.7vw,32px); line-height:1.32; letter-spacing:-.01em; margin:0; max-width:48ch; color:var(--fg);">jd-intel takes the tax off. It hands current, real postings to the assistant that already knows your background, so <em style="font-style:italic;">your</em> context does the ranking. Not a board's algorithm. Not another tab to manage.</p>
+        <p style="font-family:var(--display-font); font-weight:400; font-size:clamp(24px,2.7vw,32px); line-height:1.32; letter-spacing:-.01em; margin:0; color:var(--fg);">jd-intel takes the tax off. It hands current, real postings to the assistant that already knows your background, so <em style="font-style:italic;">your</em> context does the ranking. Not a board's algorithm. Not another tab to manage.</p>
       </div>
     </section>
 
     <!-- ============ HOW IT WORKS ============ -->
     <section id="how" style="padding:calc(92px * var(--pad-scale)) 0; border-top:1px solid var(--line);">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:22px;">How it works</div>
-      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 56px; max-width:18ch;">Set it up once. Then you just ask.</h2>
+      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 56px;">Set it up once. Then you just ask.</h2>
 
       <div style="display:grid; grid-template-columns:1fr; gap:0;">
         <div style="display:grid; grid-template-columns:88px 1fr 1fr; gap:34px; align-items:start; padding:0 0 36px; border-bottom:1px solid var(--line);">
@@ -149,7 +149,7 @@
       <div style="display:grid; grid-template-columns:1.05fr .95fr; gap:60px; align-items:center;">
         <div>
           <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:22px;">Even better with context</div>
-          <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(30px,3.5vw,42px); line-height:1.1; letter-spacing:-.02em; margin:0 0 18px; max-width:18ch;">The more your AI knows you, the sharper the answers.</h2>
+          <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(30px,3.5vw,42px); line-height:1.1; letter-spacing:-.02em; margin:0 0 18px;">The more your AI knows you, the sharper the answers.</h2>
           <p style="font:400 17.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 16px;">Point your assistant at a project or chat that holds your resume, your target titles, the things you will and will not do. jd-intel brings the current openings. Your AI does the matching, the way a sharp friend who knows your work would.</p>
           <p style="font:400 17.5px/1.62 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0;">Nothing about your profile leaves your machine to make this work. It is the context your assistant already has.</p>
         </div>
@@ -169,7 +169,7 @@
     <!-- ============ UNDER THE HOOD / COVERAGE ============ -->
     <section id="coverage" style="padding:calc(92px * var(--pad-scale)) 0; border-top:1px solid var(--line);">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:22px;">Under the hood, for those who care</div>
-      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 56px; max-width:16ch;">Built on stable ground.</h2>
+      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 56px;">Built on stable ground.</h2>
 
       <div style="display:grid; grid-template-columns:repeat(3,1fr); gap:40px; margin-bottom:60px;">
         <div>
@@ -210,8 +210,8 @@
     <!-- ============ INSTALL ============ -->
     <section id="install" style="padding:calc(92px * var(--pad-scale)) 0; border-top:1px solid var(--line);">
       <div style="font:500 12.5px/1 'JetBrains Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--fg-3); margin-bottom:22px;">Install</div>
-      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 14px; max-width:16ch;">Two minutes. No terminal.</h2>
-      <p style="font:400 18px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); max-width:560px; margin:0 0 48px;">Claude Desktop runs jd-intel for you on its own bundled runtime. Nothing else to install.</p>
+      <h2 style="font-family:var(--display-font); font-weight:500; font-size:clamp(32px,3.8vw,44px); line-height:1.08; letter-spacing:-.02em; margin:0 0 14px;">Two minutes. No terminal.</h2>
+      <p style="font:400 18px/1.6 'Schibsted Grotesk',sans-serif; color:var(--fg-2); margin:0 0 48px;">Claude Desktop runs jd-intel for you on its own bundled runtime. Nothing else to install.</p>
 
       <div style="display:grid; grid-template-columns:1.3fr 1fr; gap:22px; align-items:start;">
         <div style="border:1px solid var(--line-2); border-radius:15px; padding:32px 34px; background:var(--surface); box-shadow:var(--shadow);">


### PR DESCRIPTION
Adds a changelog page to the site and updates the registry count claims now that the expansion backlog has merged.

## Why

The registry grew from 355 to 522 entries today, but nothing on the site said so. Raw counts also do not tell a visitor anything useful: "+43 across 7 ATS" is a fact about files, not about what they can search.

## The page

`docs/changelog.html` is written in coverage terms. Growth is stated as a percentage against the size of each field before the release, which stays meaningful as the registry gets bigger:

- Energy, climate and industrial: +200%
- Healthcare and life sciences: +173%
- Gaming and entertainment: +105%
- Retail, consumer and ecommerce: +57%
- Finance and payments: +22%
- AI and developer tools: +18%

Regional growth is expressed through the platforms that carry it, since the registry stores sector but not region. Recruitee (Netherlands, Germany, Belgium) is up 129%, TeamTailor (Nordics) up 42%, SmartRecruiters up 128%.

There is also a section on the five companies that changed hiring platform and were re-pointed, which is the kind of maintenance a count never shows.

## Honesty guardrails

Two deliberate choices worth flagging for review:

1. The page presents this as **one release dated 23 August 2026 containing five verification runs**, rather than five separate dated releases. The runs happened across five weeks but all shipped today, so five dated entries would imply a delivery cadence that did not happen.
2. The "How this is verified" section states that coverage is accurate **as of the date on each release, not permanently**, and points at `npm run verify:registry` so anyone can check. A standing "verified" claim we stop honouring would be worse than no claim.

## Count claims

Registry crossed both the 400 and 500 boundaries, so `300+` becomes `500+` in `README.md`, `docs/index.html`, `CLAUDE.md`, and `AGENTS.md`.

## Verification

- 142 tests passing
- No em dashes in the new prose, per the voice rules
- All 14 CSS custom properties referenced are defined in `styles.css`; block tags balanced; all 24 links resolve
- Cache-bust suffix left at `v=20260627c` because `styles.css` and `theme.js` are unchanged
- Browser preview was not available in this session, so verification was structural rather than visual. Worth a look in a browser before merging, particularly the stat row at narrow widths.
